### PR TITLE
Make init() run before C++ static initializers

### DIFF
--- a/variants/arduino_due_x/variant.cpp
+++ b/variants/arduino_due_x/variant.cpp
@@ -380,9 +380,6 @@ void init( void )
     while (true);
   }
 
-  // Initialize C library
-  __libc_init_array();
-
   // Disable pull-up on every pin
   for (unsigned i = 0; i < PINS_COUNT; i++)
 	  digitalWrite(i, LOW);
@@ -445,6 +442,9 @@ void init( void )
 
   // Initialize analogOutput module
   analogOutputInit();
+
+  // Initialize C library and run C++ constructors
+  __libc_init_array();
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Partially moved from https://github.com/arduino/Arduino/pull/5592

_eric-wieser commented on 12 Nov 2016_
_Before this change, the contents of init() run after .init6 which is when static initializers run._

_However, this is not desirable:_

_init() does not need any C++ classes to be active
C++ static initialization sometimes does require that the hardware be pre-configured!
This makes it possible to make calls like Serial.begin() inside constructors of global variables._