### PR TITLE
Add virtual beginMulticast(...) stub to UDP class

### DIFF
--- a/cores/arduino/Udp.h
+++ b/cores/arduino/Udp.h
@@ -41,7 +41,8 @@
 class UDP : public Stream {
 
 public:
-  virtual uint8_t begin(uint16_t) =0;	// initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
+  virtual uint8_t begin(uint16_t) =0;  // initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
+  virtual uint8_t beginMulticast(IPAddress, uint16_t) { return 0; }  // initialize, start listening on specified multicast IP address and port. Returns 1 if successful, 0 on failure
   virtual void stop() =0;  // Finish with the UDP socket
 
   // Sending UDP packets


### PR DESCRIPTION
Moved from https://github.com/arduino/Arduino/pull/5796

_sandeepmistry commented 21 days ago_
_This allows libraries to use udp.beginMulti(..) when a UDP type is passed in. This method is optional and will fail by default if the network library does not support multicast UDP._