### PR TITLE
Add isFlushed() method to serial classes

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -142,6 +142,11 @@ void UARTClass::flush( void )
    ;
 }
 
+bool UARTClass::isFlushed( void )
+{
+  return ((_pUart->UART_SR & UART_SR_TXRDY) == UART_SR_TXRDY) && (_tx_buffer->_iTail == _tx_buffer->_iHead);
+}
+
 size_t UARTClass::write( const uint8_t uc_data )
 {
   // Is the hardware currently busy?

--- a/cores/arduino/UARTClass.h
+++ b/cores/arduino/UARTClass.h
@@ -52,6 +52,7 @@ class UARTClass : public HardwareSerial
     int peek(void);
     int read(void);
     void flush(void);
+    bool isFlushed(void);
     size_t write(const uint8_t c);
     using Print::write; // pull in write(str) and write(buf, size) from Print
 


### PR DESCRIPTION
Add isFlushed() to HardwareSerial class for AVR and to UARTClass class
for SAM. This provides a non-blocking way to check if the transmit
buffer is flushed.

Partially moved from https://github.com/arduino/Arduino/pull/3737