### PR TITLE
attachInterrupt with std::function

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -204,7 +204,9 @@ extern const PinDescription g_APinDescription[] ;
 #include "wiring_digital.h"
 #include "wiring_analog.h"
 #include "wiring_shift.h"
+#ifdef __cplusplus
 #include "WInterrupts.h"
+#endif // __cplusplus
 
 #include "watchdog.h"
 

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -21,6 +21,8 @@
 #include "PluggableUSB.h"
 #include <stdint.h>
 
+#define _min(a, b)           (((a) < (b)) ?  (a) : (b))
+
 //#define TRACE_CORE(x)	x
 #define TRACE_CORE(x)
 
@@ -144,7 +146,7 @@ uint32_t USBD_Recv(uint32_t ep, void* d, uint32_t len)
 
 	LockEP lock(ep);
 	uint32_t n = UDD_FifoByteCount(ep & 0xF);
-	len = min(n,len);
+	len = _min(n,len);
 	n = len;
 	uint8_t* dst = (uint8_t*)d;
 	while (n--)

--- a/cores/arduino/WInterrupts.cpp
+++ b/cores/arduino/WInterrupts.cpp
@@ -8,17 +8,24 @@
 
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   See the GNU Lesser General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
+namespace std
+{
+void __throw_bad_function_call()
+{
+//Log.Error(F("STL ERROR - HALT NOW"));
+}
+}
 #include "WInterrupts.h"
 
-typedef void (*interruptCB)(void);
+//typedef void (*interruptCB)(void);
+typedef std::function<void(void)> interruptCB;
 
 static interruptCB callbacksPioA[32];
 static interruptCB callbacksPioB[32];
@@ -60,8 +67,17 @@ static void __initialize() {
 	NVIC_EnableIRQ(PIOD_IRQn);
 }
 
+// void attachInterrupt(uint32_t pin, std::function<void(void)> callback, uint32_t mode){
+//
+// }
 
-void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode)
+void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode){
+	std::function<void(void)> _callback =callback;
+	attachInterrupt(pin,_callback,mode);
+}
+
+// void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode)
+void attachInterrupt(uint32_t pin, std::function<void(void)> callback, uint32_t mode)
 {
 	static int enabled = 0;
 	if (!enabled) {

--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -8,7 +8,7 @@
 
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   See the GNU Lesser General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
@@ -21,16 +21,19 @@
 
 #include "Arduino.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <functional>
 
+// #ifdef __cplusplus
+// extern "C" {
+// #endif
+
+void attachInterrupt(uint32_t pin, std::function<void(void)>, uint32_t mode);
 void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode);
 
 void detachInterrupt(uint32_t pin);
 
-#ifdef __cplusplus
-}
-#endif
+// #ifdef __cplusplus
+// }
+// #endif
 
 #endif /* _WIRING_INTERRUPTS_ */


### PR DESCRIPTION
Moved from https://github.com/arduino/Arduino/pull/5831

@straccio commented 14 days ago

A way to add member function for an interrupt callback.

std::function<void()> int_func =std::bind(&button::press,this);
attachInterrupt(digitalPinToInterrupt(pin),int_func,FALLING);