### PR TITLE
Remove warnings "-Wreorder" and "-Wunused-parameter"

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -18,6 +18,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreorder"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 extern "C" {
 #include <string.h>
 }
@@ -445,3 +449,5 @@ void WIRE1_ISR_HANDLER(void) {
 	Wire1.onService();
 }
 #endif
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Compiling Wire.cpp with all warnings enabled generates a lot of warnings (of type "-Wreorder" and "-Wunused-parameter"). I don't know why and what changes should be made to the code to avoid that, so I simply put a #pragma GCC diagnostic push/ignored/pop in order to temporarily fix that.