### PR TITLE
Fix for pgm_read_ptr macro

### DIFF
--- a/cores/arduino/avr/pgmspace.h
+++ b/cores/arduino/avr/pgmspace.h
@@ -103,7 +103,7 @@ typedef const void* uint_farptr_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
-#define pgm_read_ptr(addr) (*(const void *)(addr))
+#define pgm_read_ptr(addr) (*(const void **)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)


### PR DESCRIPTION
There’s an error in `avr/pgmspace.h` that leads to errors if one uses `pgm_read_ptr` macro on SAM platform:

```
.../cores/arduino/avr/pgmspace.h:106:49: error: 'const void*' is not a pointer-to-object type
 #define pgm_read_ptr(addr) (*(const void *)(addr))
                                                 ^
```

Given the double indirection (the first is `addr` and the second is data itself) we should use `void**`, not `void*`.

Fixes #35 