### PR TITLE
Support extra parameter on `attachInterrupt()

### DIFF
--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode);
-
+void attachInterruptParam(uint32_t pin, void (*callback)(void*), uint32_t mode, void* param);
 void detachInterrupt(uint32_t pin);
 
 #ifdef __cplusplus


### PR DESCRIPTION
When writing an arduino library, it is difficult to connect interrupt handlers with the component instance that should be notified.

In C, the common pattern to fix this is to specifying a void* parameter with the callback, where the listener can store any context necessary.

This patch adds the new function attachInterruptParam() to implement this pattern.

This PR mirrors the changes for AVR on https://github.com/arduino/Arduino/pull/4519.