### PR TITLE
Remove printf call from _exit in syscalls_sam3.c

### DIFF
--- a/cores/arduino/syscalls_sam3.c
+++ b/cores/arduino/syscalls_sam3.c
@@ -132,7 +132,8 @@ extern int _write( UNUSED(int file), char *ptr, int len )
 
 extern void _exit( int status )
 {
-    printf( "Exiting with status %d.\n", status ) ;
+//  printf is probably not set up by Arduino, and shouldn't be used.
+//    printf( "Exiting with status %d.\n", status ) ;
 
     for ( ; ; ) ;
 }


### PR DESCRIPTION
The use of printf here is problematic (stdio and/or uart is
probably not even set up) and expensive (~10k of code!)
See https://github.com/arduino/ArduinoCore-sam/issues/47