### PR TITLE
Ensure correct version of arm-none-eabi-gcc

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+compiler.path={runtime.tools.arm-none-eabi-gcc-4.8.3-2014q1.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD
 compiler.c.elf.cmd=arm-none-eabi-gcc


### PR DESCRIPTION
When you have multiple versions of the same tool installed on your machine, for example `4.8.3-2014q1` and `7-2017q4`, it's best to specify the version, or it will fail.