### PR TITLE
Add rounding to Baud Rate Divisor calculation.  Permits operation at …

### DIFF
--- a/cores/arduino/UARTClass.cpp
+++ b/cores/arduino/UARTClass.cpp
@@ -60,8 +60,8 @@ void UARTClass::init(const uint32_t dwBaudRate, const uint32_t modeReg)
   // Configure mode
   _pUart->UART_MR = modeReg;
 
-  // Configure baudrate (asynchronous, no oversampling)
-  _pUart->UART_BRGR = (SystemCoreClock / dwBaudRate) >> 4;
+  // Configure baudrate (asynchronous, no oversampling, with rounding)
+  _pUart->UART_BRGR = ((SystemCoreClock / dwBaudRate)+8) >> 4;
 
   // Configure interrupts
   _pUart->UART_IDR = 0xFFFFFFFF;


### PR DESCRIPTION
The Baud Rate Generator Divisor calculations in UARTClass::init() do not round, leading to error rates higher than they could be. In particular, the error at 230400bps is both large and in the opposite direction of the 16u2 error, and it fails. Adding rounding allows it to work.

regression tested at standard speeds 9600, 19200, 38400, 57600, 115200...