### PR TITLE
USB: Check on the number of bytes to send to not send more than expected

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -229,6 +229,11 @@ int USBD_SendControl(uint8_t flags __attribute__ ((unused)), const void* d, uint
 
 	if (_cmark < _cend)
 	{
+	    if (_cmark + len > _cend)
+	    {
+	        len = _cend - _cmark;
+	        length = len;
+	    }
 		while (len > 0)
 		{
 			sent = UDD_Send(EP0, data + pos, len);


### PR DESCRIPTION
Previously if `_cmark` was less than _cend but the length to send is more than `_cend - _cmark` then the device will send more data than expected and may crash the host driver.