### PR TITLE
Update uotghs_host.c

### DIFF
--- a/system/libsam/source/uotghs_host.c
+++ b/system/libsam/source/uotghs_host.c
@@ -360,7 +360,7 @@ void UHD_Pipe_Free(uint32_t ul_pipe)
 uint32_t UHD_Pipe_Read(uint32_t ul_pipe, uint32_t ul_size, uint8_t* data)
 {
 	uint8_t *ptr_ep_data = 0;
-	uint8_t nb_byte_received = 0;
+	uint16_t nb_byte_received = 0; //otherwise roll over when reading pipe >256 Bytes
 	uint32_t ul_nb_trans = 0;
 
 	// Get information to read data

--- a/system/libsam/source/uotghs_host.c
+++ b/system/libsam/source/uotghs_host.c
@@ -360,7 +360,7 @@ void UHD_Pipe_Free(uint32_t ul_pipe)
 uint32_t UHD_Pipe_Read(uint32_t ul_pipe, uint32_t ul_size, uint8_t* data)
 {
 	uint8_t *ptr_ep_data = 0;
-	uint16_t nb_byte_received = 0; //otherwise roll over when reading pipe >256 Bytes
+	uint16_t nb_byte_received = 0; //counts bytes received from pipe (max. 1024 on SAM3x8E)
 	uint32_t ul_nb_trans = 0;
 
 	// Get information to read data


### PR DESCRIPTION
If you try to read longer messages (>256 bytes)  from USB device from host side, the buffer rolls over overwriting the buffer.
For DUE/SAM can handle pipes with 1024 bytes, a  **uint16_t**   should be used here.

I needed this for example to be able to read 512 bytes of data from a USB-Midi device.