### PR TITLE
added weak attribute to UART handlers

### DIFF
--- a/variants/arduino_due_x/variant.cpp
+++ b/variants/arduino_due_x/variant.cpp
@@ -336,20 +336,24 @@ void serialEvent3() __attribute__((weak));
 void serialEvent3() { }
 
 // IT handlers
+void USART0_Handler(void) __attribute__((weak)); 
 void USART0_Handler(void)
 {
   Serial1.IrqHandler();
 }
 
+void USART1_Handler(void) __attribute__((weak)); 
 void USART1_Handler(void)
 {
   Serial2.IrqHandler();
 }
 
+void USART3_Handler(void) __attribute__((weak)); 
 void USART3_Handler(void)
 {
   Serial3.IrqHandler();
 }
+
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
added __weak__ attribute to UART handlers to allow custom handlers override default UART routine
That is vital changes to implement DMX512 protocol over UART (for example) without manual changes of CORE libraries