### PR TITLE
added optional custom handler to Serial interrupt

### DIFF
--- a/cores/arduino/UARTClass.h
+++ b/cores/arduino/UARTClass.h
@@ -31,6 +31,9 @@
 #define SERIAL_8M1 UARTClass::Mode_8M1
 #define SERIAL_8S1 UARTClass::Mode_8S1
 
+// missing in CMSIS
+#define UART_SR_RXBRK (0x1u << 2)
+
 
 class UARTClass : public HardwareSerial
 {
@@ -60,6 +63,10 @@ class UARTClass : public HardwareSerial
 
     void IrqHandler(void);
 
+    typedef void (*USART_isr_t)(uint8_t data, uint32_t status);
+    void attachInterrupt( USART_isr_t fn );
+    void detachInterrupt() { attachInterrupt( (USART_isr_t) NULL ); };
+
     operator bool() { return true; }; // UART always active
 
   protected:
@@ -72,6 +79,7 @@ class UARTClass : public HardwareSerial
     IRQn_Type _dwIrq;
     uint32_t _dwId;
 
+    USART_isr_t  _isr;
 };
 
 #endif // _UART_CLASS_

--- a/cores/arduino/UARTClass.h
+++ b/cores/arduino/UARTClass.h
@@ -34,7 +34,6 @@
 // missing in CMSIS
 #define UART_SR_RXBRK (0x1u << 2)
 
-
 class UARTClass : public HardwareSerial
 {
   public:
@@ -63,9 +62,12 @@ class UARTClass : public HardwareSerial
 
     void IrqHandler(void);
 
-    typedef void (*USART_isr_t)(uint8_t data, uint32_t status);
-    void attachInterrupt( USART_isr_t fn );
-    void detachInterrupt() { attachInterrupt( (USART_isr_t) NULL ); };
+    typedef void (* isrRx_t)(uint8_t data, uint32_t status);
+    typedef void (* isrTx_t)( void );
+    void attachInterrupt_Receive( isrRx_t fn );
+    void detachInterrupt_Receive( void ) { attachInterrupt_Receive( (isrRx_t) NULL); };
+    void attachInterrupt_Send( isrTx_t fn );
+    void detachInterrupt_Send( void ) { attachInterrupt_Send( (isrTx_t) NULL); };
 
     operator bool() { return true; }; // UART always active
 
@@ -79,7 +81,8 @@ class UARTClass : public HardwareSerial
     IRQn_Type _dwIrq;
     uint32_t _dwId;
 
-    USART_isr_t  _isr;
+    isrRx_t  _isrRx;
+    isrTx_t  _isrTx;
 };
 
 #endif // _UART_CLASS_


### PR DESCRIPTION
added optional custom handler to Serial interrupt. Is similar to
NeoHWSerial by SlashDevin (https://github.com/SlashDevin/NeoHWSerial),
but:

- user function also gets UART status as parameter to e.g. detect LIN
break in user routine.

- ported to Arduino Due

Added as core extension because AFAIK cannot be implemented as library
for Due. Also note similar pull request for AVR
(https://github.com/arduino/ArduinoCore-avr/pull/297)