### PR TITLE
Fix for Issue #106 (Artificial delay in SerialUSB bool operator)

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -311,7 +311,6 @@ Serial_::operator bool()
 		result = true;
 	}
 
-	delay(10);
 	return result;
 }
 


### PR DESCRIPTION
Fix for [https://github.com/arduino/ArduinoCore-sam/issues/106](https://github.com/arduino/ArduinoCore-sam/issues/106)
Removed delay in CDC Driver to check for connected state in Serial_::operator bool()