### PR TITLE
Some build rule fixes (fix use of libstdc++ and printf)

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -19,7 +19,7 @@ compiler.warning_flags.all=-Wall -Wextra
 
 compiler.path={runtime.tools.arm-none-eabi-gcc-4.8.3-2014q1.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD
+compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD
 compiler.c.elf.cmd=arm-none-eabi-g++
 compiler.c.elf.flags=-Os -Wl,--gc-sections
 compiler.S.cmd=arm-none-eabi-gcc

--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@ compiler.warning_flags.all=-Wall -Wextra
 compiler.path={runtime.tools.arm-none-eabi-gcc-4.8.3-2014q1.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD
-compiler.c.elf.cmd=arm-none-eabi-gcc
+compiler.c.elf.cmd=arm-none-eabi-g++
 compiler.c.elf.flags=-Os -Wl,--gc-sections
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD


### PR DESCRIPTION
These are just two minor fixes I noticed when trying a somewhat more complicated sketch using libstdc++ for SAM. One is really a fix, the other is the second half of an earlier fix by @facchinm.