### PR TITLE
added void cast in syscall

### DIFF
--- a/cores/arduino/syscalls_sam3.c
+++ b/cores/arduino/syscalls_sam3.c
@@ -134,7 +134,8 @@ extern void _exit( int status )
 {
 //  printf is probably not set up by Arduino, and shouldn't be used.
 //    printf( "Exiting with status %d.\n", status ) ;
-
+	// To get rid of compiler warning 
+	( void ) status; 
     for ( ; ; ) ;
 }
 

--- a/cores/arduino/syscalls_sam3.c
+++ b/cores/arduino/syscalls_sam3.c
@@ -134,8 +134,8 @@ extern void _exit( int status )
 {
 //  printf is probably not set up by Arduino, and shouldn't be used.
 //    printf( "Exiting with status %d.\n", status ) ;
-	// To get rid of compiler warning 
-	( void ) status; 
+    // To get rid of compiler warning 
+    ( void ) status; 
     for ( ; ; ) ;
 }
 


### PR DESCRIPTION
status variable is not used and compiler emits a warning. I added a void cast to avoid this.