### PR TITLE
Prevent unused parameter warning

### DIFF
--- a/cores/arduino/syscalls_sam3.c
+++ b/cores/arduino/syscalls_sam3.c
@@ -130,7 +130,7 @@ extern int _write( UNUSED(int file), char *ptr, int len )
     return iIndex ;
 }
 
-extern void _exit( int status )
+extern void _exit( UNUSED(int status) )
 {
 //  printf is probably not set up by Arduino, and shouldn't be used.
 //    printf( "Exiting with status %d.\n", status ) ;


### PR DESCRIPTION
While testing something unrelated (I don't actually own a SAM board) I noticed the compiler was generating a warning:

> syscalls_sam3.c:133:24: warning: unused parameter 'status' [-Wunused-parameter]

So I thought I'd submit a PR to fix the issue. By the looks of the commented-out `printf`, it seems that not marking `status` as `UNUSED` after commenting out the `printf` was probably just an oversight.