### PR TITLE
Updated tools to newer version (same versions as Arduino-samd).

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
-compiler.path={runtime.tools.arm-none-eabi-gcc-4.8.3-2014q1.path}/bin/
+compiler.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD
 compiler.c.elf.cmd=arm-none-eabi-gcc
@@ -96,7 +96,7 @@ recipe.size.regex=\.text\s+([0-9]+).*
 # -------------------
 
 # BOSSA
-tools.bossac.path={runtime.tools.bossac.path}
+tools.bossac.path={runtime.tools.bossac-1.7.0-arduino3.path}
 tools.bossac.cmd=bossac
 tools.bossac.cmd.windows=bossac.exe
 


### PR DESCRIPTION
These versions also do have an ARM64 versions.

For this change to work properly (without having cores installed that also use these tools - e.g. Arduino-samd) we also need to update the core package_index.json.

Signed-off-by: Josef Wegner <josef.wegner@outlook.com>