### PR TITLE
Allow customization of transmit and receive buffer sizes for I2C 'Wire' and 'Wire1' objects.

### DIFF
--- a/libraries/Wire/examples/master_reader/master_reader.ino
+++ b/libraries/Wire/examples/master_reader/master_reader.ino
@@ -12,21 +12,19 @@
 
 #include <Wire.h>
 
-void setup()
-{
-  Wire.begin();        // join i2c bus (address optional for master)
+void setup() {
+  Wire.begin();        // join I2C bus (address optional for master)
   Serial.begin(9600);  // start serial for output
 }
 
-void loop()
-{
-  Wire.requestFrom(2, 6);    // request 6 bytes from slave device #2
+void loop() {
+  Wire.requestFrom(8, 6);    // request 6 bytes from slave device #8
 
-  while(Wire.available())    // slave may send less than requested
-  { 
+  while (Wire.available()) { // slave may send less than requested
     char c = Wire.read(); // receive a byte as character
     Serial.print(c);         // print the character
   }
+  Serial.println();
 
   delay(500);
 }

--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -1,6 +1,6 @@
 // Wire Master Reader Custom Buffer
 
-// Demonstrates use of the Wire library
+// Demonstrates use of the Wire library with customized buffers
 // Reads data from an I2C/TWI slave device
 // Refer to the "Wire Slave Sender Custom Buffer" example for use with this
 

--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -38,7 +38,7 @@ void loop() {
   Wire.requestFrom(8, REQUESTED_BYTE_COUNT);
 
   while (Wire.available()) { // slave may send less than requested
-    char c = Wire.read(); // receive a byte as character
+    const char c = Wire.read(); // receive a byte as character
     Serial.print(c);         // print the character
   }
   Serial.println();
@@ -76,7 +76,7 @@ void loop() {
   Wire1.requestFrom(8, REQUESTED_BYTE_COUNT);
 
   while (Wire1.available()) { // slave may send less than requested
-    char c = Wire1.read(); // receive a byte as character
+    const char c = Wire1.read(); // receive a byte as character
     Serial.print(c);         // print the character
   }
   Serial.println();

--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -30,7 +30,7 @@ void setup() {
   Wire.begin();        // join I2C bus (address optional for master)
   Serial.begin(9600);  // start serial for output
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   printWireBuffersCapacity(Serial);
 }
 
@@ -68,7 +68,7 @@ void setup() {
   Wire1.begin();        // join I2C bus (address optional for master)
   Serial.begin(9600);  // start serial for output
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   printWire1BuffersCapacity(Serial);
 }
 

--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -66,7 +66,7 @@ SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
 
 void setup() {
   Wire1.begin();        // join I2C bus (address optional for master)
-  Serial.begin(9600);  // start serial for output
+  Serial.begin(9600);   // start serial for output
 
   // This is just for curiosity and could be removed
   printWire1BuffersCapacity(Serial);

--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -1,0 +1,65 @@
+// Wire Master Reader Custom Buffer
+
+// Demonstrates use of the Wire library
+// Reads data from an I2C/TWI slave device
+// Refer to the "Wire Slave Sender Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <TwoWireBuffers.h>
+
+// request 6 bytes from slave device #8
+size_t constexpr REQUESTED_BYTE_COUNT = 6;
+
+/**** Begin Customize buffers ****/
+// Note: If you spell namespace 'WireBuffers' wrongly, all buffer
+// sizes of the 'Wire' object stay at default (32 bytes).
+namespace WireBuffers {
+  size_t constexpr RECEIVE_BUFFER_SIZE  = REQUESTED_BYTE_COUNT;
+  size_t constexpr TRANSMIT_BUFFER_SIZE = 0; // There is no transmit in this sketch.
+  // We operate as a master only, so we use the macro that will set slave buffers to zero.
+  SET_BUFFERS_FOR_MASTER_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
+}
+/**** End Customize buffers ******/
+
+// This is just for curiosity.
+// Set to false if you don't want to see actual buffer sizes on serial monitor.
+#define VERBOSE true
+
+void setup() {
+  Wire.begin();        // join I2C bus (address optional for master)
+  Serial.begin(9600);  // start serial for output
+#if VERBOSE
+  printWireBuffers();
+#endif
+}
+
+void loop() {
+  Wire.requestFrom(8, REQUESTED_BYTE_COUNT);
+
+  while (Wire.available()) { // slave may send less than requested
+    char c = Wire.read(); // receive a byte as character
+    Serial.print(c);         // print the character
+  }
+  Serial.println();
+
+  delay(500);
+}
+
+#if VERBOSE
+void printWireBuffers() {
+  delay(100);
+  Serial.println();
+  Serial.print("Wire transmit buffer size is ");
+  Serial.println(Wire.txBufferCapacity());
+  Serial.print("Wire receive buffer size is ");
+  Serial.println(Wire.rxBufferCapacity());
+  Serial.print("Wire service buffer size is ");
+  Serial.println(Wire.srvBufferCapacity());
+  delay(500);
+}
+#endif

--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -23,7 +23,7 @@ constexpr size_t TRANSMIT_BUFFER_SIZE = 0; // There is no transmit in this sketc
 
 #if not USE_WIRE1
 
-SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
@@ -47,7 +47,7 @@ void loop() {
 }
 
 void printWireBuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_Wire_BUFFERS();
 
   stream.print("Wire transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());
@@ -61,7 +61,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
 #else
 
-SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
@@ -85,7 +85,7 @@ void loop() {
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE1_BUFFERS();
+  const auto& buffers = GET_Wire1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/master_writer/master_writer.ino
+++ b/libraries/Wire/examples/master_writer/master_writer.ino
@@ -17,7 +17,7 @@ void setup()
   Wire.begin(); // join i2c bus (address optional for master)
 }
 
-byte x = 0;
+static byte x = 0;
 
 void loop()
 {

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -1,6 +1,6 @@
 // Wire Master Writer Custom Buffer
 
-// Demonstrates use of the Wire library
+// Demonstrates use of the Wire library with customized buffers
 // Writes data to an I2C/TWI slave device
 // Refer to the "Wire Slave Receiver Custom Buffer" example for use with this
 

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -18,8 +18,8 @@
 // The following text will not fit into the default buffer of 32 bytes.
 static const char text[] = "You really won't believe it, but x is ";
 
-size_t constexpr RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
-size_t constexpr TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
+constexpr size_t RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
+constexpr size_t TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
 
 #if not USE_WIRE1
 
@@ -38,8 +38,8 @@ static byte x = 0;
 
 void loop() {
   Wire.beginTransmission(8); // transmit to device #8
-  Wire.write(text);        // sends five bytes
-  Wire.write(x);              // sends one byte
+  Wire.write(text);          // sends multiple bytes
+  Wire.write(x);             // sends one byte
   Wire.endTransmission();    // stop transmitting
 
   x++;
@@ -76,8 +76,8 @@ static byte x = 0;
 
 void loop() {
   Wire1.beginTransmission(8); // transmit to device #8
-  Wire1.write(text);        // sends five bytes
-  Wire1.write(x);              // sends one byte
+  Wire1.write(text);          // sends multiple bytes
+  Wire1.write(x);             // sends one byte
   Wire1.endTransmission();    // stop transmitting
 
   x++;

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -23,7 +23,7 @@ constexpr size_t TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characte
 
 #if not USE_WIRE1
 
-SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
@@ -47,7 +47,7 @@ void loop() {
 }
 
 void printWireBuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_Wire_BUFFERS();
 
   stream.print("Wire transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());
@@ -61,7 +61,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
 #else
 
-SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
@@ -85,7 +85,7 @@ void loop() {
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE1_BUFFERS();
+  const auto& buffers = GET_Wire1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -1,0 +1,65 @@
+// Wire Master Writer Custom Buffer
+
+// Demonstrates use of the Wire library
+// Writes data to an I2C/TWI slave device
+// Refer to the "Wire Slave Receiver Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <TwoWireBuffers.h>
+
+// The following text will not fit into the default buffer of 32 bytes.
+static const char text[] = "You really won't believe it, but x is ";
+
+/**** Begin Customize buffers ****/
+// Note: If you spell namespace 'WireBuffers' wrongly, all buffer sizes
+// of the 'Wire' object stay at default (32 bytes).
+namespace WireBuffers {
+  size_t constexpr RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
+  size_t constexpr TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
+  // We operate as a master only, so we use the macro that will set slave buffers to zero.
+  SET_BUFFERS_FOR_MASTER_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
+}
+/**** End Customize buffers ******/
+
+// This is just for curiosity.
+// Set to false if you don't want to see actual buffer sizes on serial monitor.
+#define VERBOSE true
+
+void setup() {
+  Wire.begin(); // join I2C bus (address optional for master)
+#if VERBOSE
+  Serial.begin(9600);           // start serial for output
+  printWireBuffers();
+#endif
+}
+
+static byte x = 0;
+
+void loop() {
+  Wire.beginTransmission(8); // transmit to device #8
+  Wire.write(text);        // sends five bytes
+  Wire.write(x);              // sends one byte
+  Wire.endTransmission();    // stop transmitting
+
+  x++;
+  delay(500);
+}
+
+#if VERBOSE
+void printWireBuffers() {
+  delay(100);
+  Serial.println();
+  Serial.print("Wire transmit buffer size is ");
+  Serial.println(Wire.txBufferCapacity());
+  Serial.print("Wire receive buffer size is ");
+  Serial.println(Wire.rxBufferCapacity());
+  Serial.print("Wire service buffer size is ");
+  Serial.println(Wire.srvBufferCapacity());
+  delay(500);
+}
+#endif

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -29,7 +29,7 @@ SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
 void setup() {
   Wire.begin(); // join I2C bus (address optional for master)
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   Serial.begin(9600);   // start serial for output
   printWireBuffersCapacity(Serial);
 }
@@ -67,7 +67,7 @@ SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
 void setup() {
   Wire1.begin(); // join I2C bus (address optional for master)
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   Serial.begin(9600);   // start serial for output
   printWire1BuffersCapacity(Serial);
 }

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -11,31 +11,27 @@
 
 #include <Wire.h>
 #include <TwoWireBuffers.h>
+#include "Arduino.h"
+
+#define USE_WIRE1 false // Set to true for using Wire1
 
 // The following text will not fit into the default buffer of 32 bytes.
 static const char text[] = "You really won't believe it, but x is ";
 
-/**** Begin Customize buffers ****/
-// Note: If you spell namespace 'WireBuffers' wrongly, all buffer sizes
-// of the 'Wire' object stay at default (32 bytes).
-namespace WireBuffers {
-  size_t constexpr RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
-  size_t constexpr TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
-  // We operate as a master only, so we use the macro that will set slave buffers to zero.
-  SET_BUFFERS_FOR_MASTER_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
-}
-/**** End Customize buffers ******/
+size_t constexpr RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
+size_t constexpr TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
 
-// This is just for curiosity.
-// Set to false if you don't want to see actual buffer sizes on serial monitor.
-#define VERBOSE true
+#if not USE_WIRE1
+
+SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
   Wire.begin(); // join I2C bus (address optional for master)
-#if VERBOSE
-  Serial.begin(9600);           // start serial for output
-  printWireBuffers();
-#endif
+
+  // This is just for curiosity and can be removed
+  Serial.begin(9600);   // start serial for output
+  printWireBuffersCapacity(Serial);
 }
 
 static byte x = 0;
@@ -50,16 +46,55 @@ void loop() {
   delay(500);
 }
 
-#if VERBOSE
-void printWireBuffers() {
-  delay(100);
-  Serial.println();
-  Serial.print("Wire transmit buffer size is ");
-  Serial.println(Wire.txBufferCapacity());
-  Serial.print("Wire receive buffer size is ");
-  Serial.println(Wire.rxBufferCapacity());
-  Serial.print("Wire service buffer size is ");
-  Serial.println(Wire.srvBufferCapacity());
+void printWireBuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE_BUFFERS();
+
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
+}
+
+#else
+
+SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire1.begin(); // join I2C bus (address optional for master)
+
+  // This is just for curiosity and can be removed
+  Serial.begin(9600);   // start serial for output
+  printWire1BuffersCapacity(Serial);
+}
+
+static byte x = 0;
+
+void loop() {
+  Wire1.beginTransmission(8); // transmit to device #8
+  Wire1.write(text);        // sends five bytes
+  Wire1.write(x);              // sends one byte
+  Wire1.endTransmission();    // stop transmitting
+
+  x++;
   delay(500);
 }
+
+void printWire1BuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE1_BUFFERS();
+
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
+}
+
 #endif

--- a/libraries/Wire/examples/slave_receiver/slave_receiver.ino
+++ b/libraries/Wire/examples/slave_receiver/slave_receiver.ino
@@ -26,6 +26,11 @@ void loop()
 
 // function that executes whenever data is received from master
 // this function is registered as an event, see setup()
+//
+// Hint: This function is called within an interrupt context.
+// That means, that there must be enough space in the Serial output
+// buffer for the characters to be printed. Otherwise the
+// Serial.print() call will lock up.
 void receiveEvent(int howMany)
 {
   while(1 < Wire.available()) // loop through all but the last

--- a/libraries/Wire/examples/slave_receiver_Wire1Wire_connected/slave_receiver_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_receiver_Wire1Wire_connected/slave_receiver_Wire1Wire_connected.ino
@@ -23,13 +23,13 @@ static const char text[] = "You really won't believe it, but x is ";
 // Wire is the master writer
 constexpr size_t M_RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
 constexpr size_t M_TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
-SET_WIRE_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
+SET_Wire_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
     true /* master buffers needed */, false /* no slave buffers needed */ );
 
 // Wire1 is the slave receiver
 constexpr size_t S_RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
 constexpr size_t S_TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
-SET_WIRE1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
+SET_Wire1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
     false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
@@ -72,7 +72,7 @@ void receiveEvent(int howMany) {
 }
 
 void printWireBuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_Wire_BUFFERS();
 
   stream.print("Wire transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());
@@ -86,7 +86,7 @@ void printWireBuffersCapacity(Stream& stream) {
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE1_BUFFERS();
+  const auto& buffers = GET_Wire1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/slave_receiver_Wire1Wire_connected/slave_receiver_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_receiver_Wire1Wire_connected/slave_receiver_Wire1Wire_connected.ino
@@ -16,7 +16,7 @@
 #include <TwoWireBuffers.h>
 #include "Arduino.h"
 
-#if WIRE_INTERFACES_COUNT > 1
+static_assert(WIRE_INTERFACES_COUNT > 1, "You need two I2C interfaces on the Arduino board to run this sketch");
 
 static const char text[] = "You really won't believe it, but x is ";
 
@@ -98,5 +98,3 @@ void printWire1BuffersCapacity(Stream& stream) {
   stream.println(buffers.srvWireBufferCapacity());
   delay(250); // Give time to free up Serial output buffer.
 }
-
-#endif

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -1,6 +1,6 @@
 // Wire Slave Receiver Custom Buffer
 
-// Demonstrates use of the Wire library
+// Demonstrates use of the Wire library with customized buffers
 // Receives data as an I2C/TWI slave device
 // Refer to the "Wire Master Writer Custom Buffer" example for use with this
 

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -20,7 +20,7 @@ constexpr size_t TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sket
 
 #if not USE_WIRE1
 
-SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
@@ -53,7 +53,7 @@ void receiveEvent(int howMany) {
 }
 
 void printWireBuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_Wire_BUFFERS();
 
   stream.print("Wire transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());
@@ -68,7 +68,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
 #else
 
-SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
@@ -101,7 +101,7 @@ void receiveEvent(int howMany) {
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE1_BUFFERS();
+  const auto& buffers = GET_Wire1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -21,14 +21,14 @@ constexpr size_t TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sket
 #if not USE_WIRE1
 
 SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
-    true /* master buffers needed */, false /* no slave buffers needed */ );
+    false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
   Wire.begin(8);                // join I2C bus with address #8
   Wire.onReceive(receiveEvent); // register event
   Serial.begin(9600);           // start serial for output
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   printWireBuffersCapacity(Serial);
 }
 
@@ -63,14 +63,14 @@ void printWireBuffersCapacity(Stream& stream) {
 #else
 
 SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
-    true /* master buffers needed */, false /* no slave buffers needed */ );
+    false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
   Wire1.begin(8);                // join I2C bus with address #8
   Wire1.onReceive(receiveEvent); // register event
   Serial.begin(9600);           // start serial for output
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   printWire1BuffersCapacity(Serial);
 }
 

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -11,29 +11,25 @@
 
 #include <Wire.h>
 #include <TwoWireBuffers.h>
+#include "Arduino.h"
 
-/**** Begin Customize buffers ****/
-// Note: If you spell namespace 'WireBuffers' wrongly, all buffer sizes
-// of the 'Wire' object stay at default (32 bytes).
-namespace WireBuffers {
-  size_t constexpr RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
-  size_t constexpr TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
-  // We operate as a slave only, so we use the macro that will set master buffers to zero.
-  SET_BUFFERS_FOR_SLAVE_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
-}
-/**** End Customize buffers ******/
+#define USE_WIRE1 true // Set to true for using Wire1
 
-// This is just for curiosity.
-// Set to false if you don't want to see actual buffer sizes on serial monitor.
-#define VERBOSE true
+size_t constexpr RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
+size_t constexpr TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
+
+#if not USE_WIRE1
+
+SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
   Wire.begin(8);                // join I2C bus with address #8
   Wire.onReceive(receiveEvent); // register event
   Serial.begin(9600);           // start serial for output
-#if VERBOSE
-  printWireBuffers();
-#endif
+
+  // This is just for curiosity and can be removed
+  printWireBuffersCapacity(Serial);
 }
 
 void loop() {
@@ -51,16 +47,59 @@ void receiveEvent(int howMany) {
   Serial.println(x);         // print the integer
 }
 
-#if VERBOSE
-void printWireBuffers() {
-  delay(100);
-  Serial.println();
-  Serial.print("Wire transmit buffer size is ");
-  Serial.println(Wire.txBufferCapacity());
-  Serial.print("Wire receive buffer size is ");
-  Serial.println(Wire.rxBufferCapacity());
-  Serial.print("Wire service buffer size is ");
-  Serial.println(Wire.srvBufferCapacity());
-  delay(500);
+void printWireBuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE_BUFFERS();
+
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
 }
+
+#else
+
+SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire1.begin(8);                // join I2C bus with address #8
+  Wire1.onReceive(receiveEvent); // register event
+  Serial.begin(9600);           // start serial for output
+
+  // This is just for curiosity and can be removed
+  printWire1BuffersCapacity(Serial);
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+void receiveEvent(int howMany) {
+  while (1 < Wire1.available()) { // loop through all but the last
+    char c = Wire1.read(); // receive byte as a character
+    Serial.print(c);         // print the character
+  }
+  int x = Wire1.read();    // receive byte as an integer
+  Serial.println(x);         // print the integer
+}
+
+void printWire1BuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE1_BUFFERS();
+
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
+}
+
 #endif

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -13,10 +13,10 @@
 #include <TwoWireBuffers.h>
 #include "Arduino.h"
 
-#define USE_WIRE1 true // Set to true for using Wire1
+#define USE_WIRE1 false // Set to true for using Wire1
 
-size_t constexpr RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
-size_t constexpr TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
+constexpr size_t RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
+constexpr size_t TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
 
 #if not USE_WIRE1
 
@@ -40,10 +40,10 @@ void loop() {
 // this function is registered as an event, see setup()
 void receiveEvent(int howMany) {
   while (1 < Wire.available()) { // loop through all but the last
-    char c = Wire.read(); // receive byte as a character
+    const char c = Wire.read(); // receive byte as a character
     Serial.print(c);         // print the character
   }
-  int x = Wire.read();    // receive byte as an integer
+  const int x = Wire.read();    // receive byte as an integer
   Serial.println(x);         // print the integer
 }
 
@@ -82,10 +82,10 @@ void loop() {
 // this function is registered as an event, see setup()
 void receiveEvent(int howMany) {
   while (1 < Wire1.available()) { // loop through all but the last
-    char c = Wire1.read(); // receive byte as a character
+    const char c = Wire1.read(); // receive byte as a character
     Serial.print(c);         // print the character
   }
-  int x = Wire1.read();    // receive byte as an integer
+  const int x = Wire1.read();    // receive byte as an integer
   Serial.println(x);         // print the integer
 }
 

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -38,13 +38,18 @@ void loop() {
 
 // function that executes whenever data is received from master
 // this function is registered as an event, see setup()
+//
+// Hint: This function is called within an interrupt context.
+// That means, that there must be enough space in the Serial output
+// buffer for the characters to be printed. Otherwise the
+// Serial.print() call will lock up.
 void receiveEvent(int howMany) {
   while (1 < Wire.available()) { // loop through all but the last
-    const char c = Wire.read(); // receive byte as a character
-    Serial.print(c);         // print the character
+    const char c = Wire.read();  // receive byte as a character
+    Serial.print(c);             // print the character
   }
-  const int x = Wire.read();    // receive byte as an integer
-  Serial.println(x);         // print the integer
+  const int x = Wire.read();     // receive byte as an integer
+  Serial.println(x);             // print the integer
 }
 
 void printWireBuffersCapacity(Stream& stream) {
@@ -58,6 +63,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
   stream.print("Wire service buffer size is ");
   stream.println(buffers.srvWireBufferCapacity());
+  delay(250); // Give time to free up Serial output buffer.
 }
 
 #else
@@ -68,7 +74,7 @@ SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
 void setup() {
   Wire1.begin(8);                // join I2C bus with address #8
   Wire1.onReceive(receiveEvent); // register event
-  Serial.begin(9600);           // start serial for output
+  Serial.begin(9600);            // start serial for output
 
   // This is just for curiosity and could be removed
   printWire1BuffersCapacity(Serial);
@@ -80,13 +86,18 @@ void loop() {
 
 // function that executes whenever data is received from master
 // this function is registered as an event, see setup()
+//
+// Hint: This function is called within an interrupt context.
+// That means, that there must be enough space in the Serial output
+// buffer for the characters to be printed. Otherwise the
+// Serial.print() call will lock up.
 void receiveEvent(int howMany) {
   while (1 < Wire1.available()) { // loop through all but the last
-    const char c = Wire1.read(); // receive byte as a character
-    Serial.print(c);         // print the character
+    const char c = Wire1.read();  // receive byte as a character
+    Serial.print(c);              // print the character
   }
-  const int x = Wire1.read();    // receive byte as an integer
-  Serial.println(x);         // print the integer
+  const int x = Wire1.read();     // receive byte as an integer
+  Serial.println(x);              // print the integer
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
@@ -100,6 +111,7 @@ void printWire1BuffersCapacity(Stream& stream) {
 
   stream.print("Wire1 service buffer size is ");
   stream.println(buffers.srvWireBufferCapacity());
+  delay(250); // Give time to free up Serial output buffer.
 }
 
 #endif

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -1,0 +1,66 @@
+// Wire Slave Receiver Custom Buffer
+
+// Demonstrates use of the Wire library
+// Receives data as an I2C/TWI slave device
+// Refer to the "Wire Master Writer Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <TwoWireBuffers.h>
+
+/**** Begin Customize buffers ****/
+// Note: If you spell namespace 'WireBuffers' wrongly, all buffer sizes
+// of the 'Wire' object stay at default (32 bytes).
+namespace WireBuffers {
+  size_t constexpr RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
+  size_t constexpr TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
+  // We operate as a slave only, so we use the macro that will set master buffers to zero.
+  SET_BUFFERS_FOR_SLAVE_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
+}
+/**** End Customize buffers ******/
+
+// This is just for curiosity.
+// Set to false if you don't want to see actual buffer sizes on serial monitor.
+#define VERBOSE true
+
+void setup() {
+  Wire.begin(8);                // join I2C bus with address #8
+  Wire.onReceive(receiveEvent); // register event
+  Serial.begin(9600);           // start serial for output
+#if VERBOSE
+  printWireBuffers();
+#endif
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+void receiveEvent(int howMany) {
+  while (1 < Wire.available()) { // loop through all but the last
+    char c = Wire.read(); // receive byte as a character
+    Serial.print(c);         // print the character
+  }
+  int x = Wire.read();    // receive byte as an integer
+  Serial.println(x);         // print the integer
+}
+
+#if VERBOSE
+void printWireBuffers() {
+  delay(100);
+  Serial.println();
+  Serial.print("Wire transmit buffer size is ");
+  Serial.println(Wire.txBufferCapacity());
+  Serial.print("Wire receive buffer size is ");
+  Serial.println(Wire.rxBufferCapacity());
+  Serial.print("Wire service buffer size is ");
+  Serial.println(Wire.srvBufferCapacity());
+  delay(500);
+}
+#endif

--- a/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
@@ -23,13 +23,13 @@ static const char text[] = "hello "; // respond with message of 6 bytes
 // Wire is the master reader
 constexpr size_t M_RECEIVE_BUFFER_SIZE  = sizeof(text)-1; // Don't need a byte for the \0
 constexpr size_t M_TRANSMIT_BUFFER_SIZE = 0; // There is no transmit in this sketch.
-SET_WIRE_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
+SET_Wire_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
     true /* master buffers needed */, false /* no slave buffers needed */ );
 
 // Wire1 is the slave sender
 constexpr size_t S_RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
 constexpr size_t S_TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
-SET_WIRE1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
+SET_Wire1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
     false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
@@ -64,7 +64,7 @@ void requestEvent() {
 
 // print Wire buffer sizes
 void printWireBuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_Wire_BUFFERS();
 
   stream.print("Wire transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());
@@ -78,7 +78,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
 // print Wire1 buffer sizes
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE1_BUFFERS();
+  const auto& buffers = GET_Wire1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
@@ -1,0 +1,94 @@
+// Wire1Wire connected (scl <-> scl1, sda <-> sda1)
+
+// Demonstrates use of the Wire library on a single Arduino board
+// with 2 Wire interfaces (like Arduino Due).
+// Uses the option of customizing the buffers.
+//
+// Wire reads data from an I2C/TWI slave device
+// Wire1 sends data as an I2C/TWI slave device
+
+// Created 02 Jan 2025
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <TwoWireBuffers.h>
+#include "Arduino.h"
+
+#if WIRE_INTERFACES_COUNT > 1
+
+static const char text[] = "hello "; // respond with message of 6 bytes
+
+// Wire is the master reader
+constexpr size_t M_RECEIVE_BUFFER_SIZE  = sizeof(text)-1; // Don't need a byte for the \0
+constexpr size_t M_TRANSMIT_BUFFER_SIZE = 0; // There is no transmit in this sketch.
+SET_WIRE_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+// Wire1 is the slave sender
+constexpr size_t S_RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
+constexpr size_t S_TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
+SET_WIRE1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Serial.begin(9600);            // start serial for output
+
+  Wire.begin();                  // master joins I2C bus (address optional for master)
+  Wire1.begin(8);                // slave joins I2C bus with address #8
+  Wire1.onRequest(requestEvent); // register slave event
+
+  // This is just for curiosity and could be removed
+  printWireBuffersCapacity(Serial);
+  printWire1BuffersCapacity(Serial);
+}
+
+void loop() {
+  Wire.requestFrom(8, M_RECEIVE_BUFFER_SIZE);
+
+  while (Wire.available()) {
+    const char c = Wire.read(); // receive a byte as character
+    Serial.print(c);            // print the character
+  }
+  Serial.println();
+
+  delay(500);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire1.write(text);
+  // as expected by master
+}
+
+// print Wire buffer sizes
+void printWireBuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE_BUFFERS();
+
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
+}
+
+// print Wire1 buffer sizes
+void printWire1BuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE_BUFFERS();
+
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
+}
+
+#endif

--- a/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
@@ -16,7 +16,7 @@
 #include <TwoWireBuffers.h>
 #include "Arduino.h"
 
-#if WIRE_INTERFACES_COUNT > 1
+static_assert(WIRE_INTERFACES_COUNT > 1, "You need two I2C interfaces on the Arduino board to run this sketch");
 
 static const char text[] = "hello "; // respond with message of 6 bytes
 
@@ -89,5 +89,3 @@ void printWire1BuffersCapacity(Stream& stream) {
   stream.print("Wire1 service buffer size is ");
   stream.println(buffers.srvWireBufferCapacity());
 }
-
-#endif

--- a/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
@@ -78,7 +78,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
 // print Wire1 buffer sizes
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_WIRE1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -1,6 +1,6 @@
 // Wire Slave Sender Custom Buffer
 
-// Demonstrates use of the Wire library
+// Demonstrates use of the Wire library with customized buffers
 // Sends data as an I2C/TWI slave device
 // Refer to the "Wire Master Reader Custom Buffer" example for use with this
 

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -84,7 +84,7 @@ void requestEvent() {
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_WIRE1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -23,13 +23,13 @@ constexpr size_t TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for
 #if not USE_WIRE1
 
 SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
-    true /* master buffers needed */, false /* no slave buffers needed */ );
+    false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
   Wire.begin(8);                // join I2C bus with address #8
   Wire.onRequest(requestEvent); // register event
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   Serial.begin(9600);
   printWireBuffersCapacity(Serial);
 }
@@ -61,13 +61,13 @@ void printWireBuffersCapacity(Stream& stream) {
 #else
 
 SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
-    true /* master buffers needed */, false /* no slave buffers needed */ );
+    false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
   Wire1.begin(8);                // join I2C bus with address #8
   Wire1.onRequest(requestEvent); // register event
 
-  // This is just for curiosity and can be removed
+  // This is just for curiosity and could be removed
   Serial.begin(9600);
   printWire1BuffersCapacity(Serial);
 }

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -22,7 +22,7 @@ constexpr size_t TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for
 
 #if not USE_WIRE1
 
-SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
@@ -46,7 +46,7 @@ void requestEvent() {
 }
 
 void printWireBuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE_BUFFERS();
+  const auto& buffers = GET_Wire_BUFFERS();
 
   stream.print("Wire transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());
@@ -60,7 +60,7 @@ void printWireBuffersCapacity(Stream& stream) {
 
 #else
 
-SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
     false /* no master buffers needed */, true /* slave buffers needed */ );
 
 void setup() {
@@ -84,7 +84,7 @@ void requestEvent() {
 }
 
 void printWire1BuffersCapacity(Stream& stream) {
-  const auto& buffers = GET_WIRE1_BUFFERS();
+  const auto& buffers = GET_Wire1_BUFFERS();
 
   stream.print("Wire1 transmit buffer size is ");
   stream.println(buffers.txWireBufferCapacity());

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -1,0 +1,64 @@
+// Wire Slave Sender Custom Buffer
+
+// Demonstrates use of the Wire library
+// Sends data as an I2C/TWI slave device
+// Refer to the "Wire Master Reader Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <TwoWireBuffers.h>
+
+static const char text[] = "hello "; // respond with message of 6 bytes
+
+/**** Begin Customize buffers ****/
+// Note: If you spell namespace 'WireBuffers' wrongly, all buffer sizes
+// of the 'Wire' object stay at default (32 bytes).
+namespace WireBuffers {
+  size_t constexpr RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
+  size_t constexpr TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
+  // We operate as a slave only, so we use the macro that will set master buffers to zero.
+  SET_BUFFERS_FOR_SLAVE_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
+}
+/**** End Customize buffers ******/
+
+// This is just for curiosity.
+// Set to false if you don't want to see actual buffer sizes on serial monitor.
+#define VERBOSE true
+
+void setup() {
+  Wire.begin(8);                // join I2C bus with address #8
+  Wire.onRequest(requestEvent); // register event
+#if VERBOSE
+  Serial.begin(9600);           // start serial for output
+  printWireBuffers();
+#endif
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire.write(text);
+  // as expected by master
+}
+
+#if VERBOSE
+void printWireBuffers() {
+  delay(100);
+  Serial.println();
+  Serial.print("Wire transmit buffer size is ");
+  Serial.println(Wire.txBufferCapacity());
+  Serial.print("Wire receive buffer size is ");
+  Serial.println(Wire.rxBufferCapacity());
+  Serial.print("Wire service buffer size is ");
+  Serial.println(Wire.srvBufferCapacity());
+  delay(500);
+}
+#endif

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -17,8 +17,8 @@
 
 static const char text[] = "hello "; // respond with message of 6 bytes
 
-size_t constexpr RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
-size_t constexpr TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
+constexpr size_t RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
+constexpr size_t TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
 
 #if not USE_WIRE1
 

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -11,31 +11,27 @@
 
 #include <Wire.h>
 #include <TwoWireBuffers.h>
+#include "Arduino.h"
+
+#define USE_WIRE1 false // Set to true for using Wire1
 
 static const char text[] = "hello "; // respond with message of 6 bytes
 
-/**** Begin Customize buffers ****/
-// Note: If you spell namespace 'WireBuffers' wrongly, all buffer sizes
-// of the 'Wire' object stay at default (32 bytes).
-namespace WireBuffers {
-  size_t constexpr RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
-  size_t constexpr TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
-  // We operate as a slave only, so we use the macro that will set master buffers to zero.
-  SET_BUFFERS_FOR_SLAVE_ONLY(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE);
-}
-/**** End Customize buffers ******/
+size_t constexpr RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
+size_t constexpr TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
 
-// This is just for curiosity.
-// Set to false if you don't want to see actual buffer sizes on serial monitor.
-#define VERBOSE true
+#if not USE_WIRE1
+
+SET_WIRE_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
 
 void setup() {
   Wire.begin(8);                // join I2C bus with address #8
   Wire.onRequest(requestEvent); // register event
-#if VERBOSE
-  Serial.begin(9600);           // start serial for output
-  printWireBuffers();
-#endif
+
+  // This is just for curiosity and can be removed
+  Serial.begin(9600);
+  printWireBuffersCapacity(Serial);
 }
 
 void loop() {
@@ -49,16 +45,55 @@ void requestEvent() {
   // as expected by master
 }
 
-#if VERBOSE
-void printWireBuffers() {
-  delay(100);
-  Serial.println();
-  Serial.print("Wire transmit buffer size is ");
-  Serial.println(Wire.txBufferCapacity());
-  Serial.print("Wire receive buffer size is ");
-  Serial.println(Wire.rxBufferCapacity());
-  Serial.print("Wire service buffer size is ");
-  Serial.println(Wire.srvBufferCapacity());
-  delay(500);
+void printWireBuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE_BUFFERS();
+
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
 }
+
+#else
+
+SET_WIRE1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire1.begin(8);                // join I2C bus with address #8
+  Wire1.onRequest(requestEvent); // register event
+
+  // This is just for curiosity and can be removed
+  Serial.begin(9600);
+  printWire1BuffersCapacity(Serial);
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire1.write(text);
+  // as expected by master
+}
+
+void printWire1BuffersCapacity(Stream& stream) {
+  const auto& buffers = GET_WIRE_BUFFERS();
+
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.txWireBufferCapacity());
+
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.rxWireBufferCapacity());
+
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.srvWireBufferCapacity());
+}
+
 #endif

--- a/libraries/Wire/src/TwoWireBuffers.cpp
+++ b/libraries/Wire/src/TwoWireBuffers.cpp
@@ -1,5 +1,5 @@
 /*
-  twi.c - TWI/I2C library for Wiring & Arduino
+  TwoWireBuffers.cpp - TWI/I2C library for Wiring & Arduino
   Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
 
   This library is free software; you can redistribute it and/or

--- a/libraries/Wire/src/TwoWireBuffers.cpp
+++ b/libraries/Wire/src/TwoWireBuffers.cpp
@@ -1,0 +1,29 @@
+/*
+  twi.c - TWI/I2C library for Wiring & Arduino
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "TwoWireBuffers.h"
+
+
+constexpr size_t RX_BUFFER_DEFAULT_LENGTH = 32;
+constexpr size_t TX_BUFFER_DEFAULT_LENGTH = 32;
+
+// Default buffers for the one and only Wire object
+namespace WireBuffers {
+  __attribute__((weak)) SET_BUFFERS_FOR_BOTH(RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH);
+} // namespace Twi

--- a/libraries/Wire/src/TwoWireBuffers.cpp
+++ b/libraries/Wire/src/TwoWireBuffers.cpp
@@ -18,12 +18,21 @@
 */
 
 #include "TwoWireBuffers.h"
-
+#include "variant.h"
 
 constexpr size_t RX_BUFFER_DEFAULT_LENGTH = 32;
 constexpr size_t TX_BUFFER_DEFAULT_LENGTH = 32;
 
-// Default buffers for the one and only Wire object
+#if WIRE_INTERFACES_COUNT > 0
+// Default buffers for the Wire object
 namespace WireBuffers {
   __attribute__((weak)) SET_BUFFERS_FOR_BOTH(RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH);
 } // namespace Twi
+#endif
+
+#if WIRE_INTERFACES_COUNT > 1
+// Default buffers for the Wire1 object
+namespace Wire1Buffers {
+  __attribute__((weak)) SET_BUFFERS_FOR_BOTH(RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH);
+} // namespace Twi
+#endif

--- a/libraries/Wire/src/TwoWireBuffers.cpp
+++ b/libraries/Wire/src/TwoWireBuffers.cpp
@@ -25,14 +25,16 @@ constexpr size_t TX_BUFFER_DEFAULT_LENGTH = 32;
 
 #if WIRE_INTERFACES_COUNT > 0
 // Default buffers for the Wire object
-namespace WireBuffers {
-  __attribute__((weak)) SET_BUFFERS_FOR_BOTH(RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH);
-} // namespace Twi
+template<> __attribute__((weak)) TwoWireBuffers::Interface& WireBuffers<0>::instance() { \
+  static TwoWireBuffers::Impl<RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH> buffers; \
+  return buffers; \
+}
 #endif
 
 #if WIRE_INTERFACES_COUNT > 1
 // Default buffers for the Wire1 object
-namespace Wire1Buffers {
-  __attribute__((weak)) SET_BUFFERS_FOR_BOTH(RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH);
-} // namespace Twi
+template<> __attribute__((weak)) TwoWireBuffers::Interface& WireBuffers<1>::instance() { \
+  static TwoWireBuffers::Impl<RX_BUFFER_DEFAULT_LENGTH, TX_BUFFER_DEFAULT_LENGTH> buffers; \
+  return buffers; \
+}
 #endif

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -1,5 +1,5 @@
 /*
-  twi.h - TWI/I2C library for Wiring & Arduino
+  TwoWireBuffers.h - TWI/I2C library for Wiring & Arduino
   Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
 
   This library is free software; you can redistribute it and/or

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -15,8 +15,6 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
-  Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
 */
 
 #pragma once

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -1,0 +1,119 @@
+/*
+  twi.h - TWI/I2C library for Wiring & Arduino
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
+*/
+
+#pragma once
+
+#ifndef TwiBuffers_h
+#define TwiBuffers_h
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace TwoWireBuffers {
+
+/* Template class that implements an compile time fixed size array. */
+template<unsigned CAPACITY>
+class StaticBuffer {
+  uint8_t mByteArray[CAPACITY];
+public:
+  inline uint8_t capacity() const {return CAPACITY;}
+  inline uint8_t* storage() {return mByteArray;}
+};
+
+/* Specialization of StaticBuffer template class with zero size. */
+template<>
+class StaticBuffer<0> {
+public:
+  inline uint8_t capacity() const {return 0;}
+  inline uint8_t* storage() {return nullptr;}
+};
+
+
+/* Interface that provides buffers for twi driver and TwoWire objects */
+class Interface {
+public:
+  virtual uint8_t* rxWireBuffer() = 0;
+  virtual size_t rxWireBufferCapacity() = 0;
+
+  virtual uint8_t* txWireBuffer() = 0;
+  virtual size_t txWireBufferCapacity() = 0;
+
+  virtual uint8_t* srvWireBuffer() = 0;
+  virtual size_t srvWireBufferCapacity() = 0;
+};
+
+/* Template class implementing Interface with template parameter
+ * determined buffer sizes.
+ */
+template<
+  size_t RX_CAPACITY, // Receive buffer size. May be zero, if only transmitting data is needed
+  size_t TX_CAPACITY, // Transmit buffer size. May be zero, if only receiving data is needed
+  bool ENABLE_MASTER,   // If master is disabled, it will save twi master buffer space
+  bool ENABLE_SLAVE     // If slave is disabled, it will save twi slave buffer space
+  >
+class Impl : public Interface {
+  static_assert(ENABLE_MASTER == true || ENABLE_SLAVE == true,
+      "You should not disable master and slave together.");
+
+  static constexpr size_t SRV_CAPACITY =
+      RX_CAPACITY > TX_CAPACITY ? RX_CAPACITY : TX_CAPACITY;
+
+  // Set the capacity for a TwoWire object.
+  TwoWireBuffers::StaticBuffer<RX_CAPACITY> mRxWireBuffer;
+  TwoWireBuffers::StaticBuffer<TX_CAPACITY> mTxWireBuffer;
+  TwoWireBuffers::StaticBuffer<SRV_CAPACITY> mSrvWireBuffer;
+
+public:
+  virtual uint8_t* rxWireBuffer() override {return mRxWireBuffer.storage();}
+  virtual size_t rxWireBufferCapacity() override {return mRxWireBuffer.capacity();}
+
+  virtual uint8_t* txWireBuffer() override {return mTxWireBuffer.storage();}
+  virtual size_t txWireBufferCapacity() override {return mTxWireBuffer.capacity();}
+
+  virtual uint8_t* srvWireBuffer() override {return mSrvWireBuffer.storage();}
+  virtual size_t srvWireBufferCapacity() override {return mSrvWireBuffer.capacity();}
+};
+
+} // namespace TwoWireBuffers
+
+namespace WireBuffers { // The buffers for the one and only Wire object
+  extern TwoWireBuffers::Interface& instance();
+}
+
+#define SET_BUFFERS_FOR_MASTER_ONLY(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
+    TwoWireBuffers::Interface& instance() { \
+      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY, true, false> instance; \
+		  return instance; \
+		}
+
+#define SET_BUFFERS_FOR_SLAVE_ONLY(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
+    TwoWireBuffers::Interface& instance() { \
+      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY, false, true> instance; \
+      return instance; \
+    }
+
+#define SET_BUFFERS_FOR_BOTH(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
+    TwoWireBuffers::Interface& instance() { \
+      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY, true, true> instance; \
+      return instance; \
+    }
+
+#endif /* TwiBuffers_h */

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -65,14 +65,10 @@ public:
  */
 template<
   size_t RX_CAPACITY, // Receive buffer size. May be zero, if only transmitting data is needed
-  size_t TX_CAPACITY, // Transmit buffer size. May be zero, if only receiving data is needed
-  bool ENABLE_MASTER,   // If master is disabled, it will save twi master buffer space
-  bool ENABLE_SLAVE     // If slave is disabled, it will save twi slave buffer space
+  size_t TX_CAPACITY  // Transmit buffer size. May be zero, if only receiving data is needed
   >
 class Impl : public Interface {
-  static_assert(ENABLE_MASTER == true || ENABLE_SLAVE == true,
-      "You should not disable master and slave together.");
-
+  // Service buffer is neede for transmit and receive.
   static constexpr size_t SRV_CAPACITY =
       RX_CAPACITY > TX_CAPACITY ? RX_CAPACITY : TX_CAPACITY;
 
@@ -94,26 +90,18 @@ public:
 
 } // namespace TwoWireBuffers
 
-namespace WireBuffers { // The buffers for the one and only Wire object
-  extern TwoWireBuffers::Interface& instance();
-}
-
-#define SET_BUFFERS_FOR_MASTER_ONLY(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
-    TwoWireBuffers::Interface& instance() { \
-      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY, true, false> instance; \
-		  return instance; \
-		}
-
-#define SET_BUFFERS_FOR_SLAVE_ONLY(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
-    TwoWireBuffers::Interface& instance() { \
-      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY, false, true> instance; \
-      return instance; \
-    }
-
 #define SET_BUFFERS_FOR_BOTH(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
     TwoWireBuffers::Interface& instance() { \
-      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY, true, true> instance; \
+      static TwoWireBuffers::Impl<RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY> instance; \
       return instance; \
     }
+
+// This macro is just for compatibility reasons with AVR core
+#define SET_BUFFERS_FOR_MASTER_ONLY(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
+    SET_BUFFERS_FOR_BOTH(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY)
+
+// This macro is just for compatibility reasons with AVR core
+#define SET_BUFFERS_FOR_SLAVE_ONLY(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY) \
+    SET_BUFFERS_FOR_BOTH(RX_BUFFER_CAPACITY, TX_BUFFER_CAPACITY)
 
 #endif /* TwiBuffers_h */

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -67,7 +67,7 @@ template<
   size_t TX_CAPACITY  // Transmit buffer size. May be zero, if only receiving data is needed
   >
 class Impl : public Interface {
-  // Service buffer is neede for transmit and receive.
+  // Service buffer is needed for transmit and receive.
   static constexpr size_t SRV_CAPACITY =
       RX_CAPACITY > TX_CAPACITY ? RX_CAPACITY : TX_CAPACITY;
 

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -105,17 +105,17 @@ template<size_t wireNum> struct WireBuffers { // The buffers for the Wire object
 #define GET_WIRE_BUFFERS_(wireNum) WireBuffers<wireNum>::instance()
 
 #if WIRE_INTERFACES_COUNT > 0
-  #define SET_WIRE_BUFFERS(rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave) \
+  #define SET_Wire_BUFFERS(rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave) \
     SET_WIRE_BUFFERS_(0, rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave)
 
-  #define GET_WIRE_BUFFERS() GET_WIRE_BUFFERS_(0)
+  #define GET_Wire_BUFFERS() GET_WIRE_BUFFERS_(0)
 #endif
 
 #if WIRE_INTERFACES_COUNT > 1
-  #define SET_WIRE1_BUFFERS(rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave) \
+  #define SET_Wire1_BUFFERS(rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave) \
      SET_WIRE_BUFFERS_(1, rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave)
 
-  #define GET_WIRE1_BUFFERS() GET_WIRE_BUFFERS_(1)
+  #define GET_Wire1_BUFFERS() GET_WIRE_BUFFERS_(1)
 #endif
 
 #endif /* TwiBuffers_h */

--- a/libraries/Wire/src/TwoWireBuffers.h
+++ b/libraries/Wire/src/TwoWireBuffers.h
@@ -93,6 +93,9 @@ template<size_t wireNum> struct WireBuffers { // The buffers for the Wire object
   static TwoWireBuffers::Interface& instance();
 };
 
+// Note: enableMaster and enableSlave don't have any impact on sam architecture, but they
+//   are present to keep the macro compatible with the one on the avr architecture, where
+//   it makes a difference in regard to memory consumption.
 #define SET_WIRE_BUFFERS_(wireNum, rxBufferCapacity, txBufferCapacity, enableMaster, enableSlave) \
     template<> TwoWireBuffers::Interface& WireBuffers<wireNum>::instance() { \
       static TwoWireBuffers::Impl<rxBufferCapacity, txBufferCapacity> buffers; \

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -172,32 +172,12 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 	return readed;
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint32_t) 0, (uint8_t) 0, (uint8_t) sendStop);
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint8_t) true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint8_t) true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint8_t) sendStop);
-}
-
 void TwoWire::beginTransmission(uint8_t address) {
 	status = MASTER_SEND;
 
 	// save address of target and empty buffer
 	txAddress = address;
 	txBufferLength = 0;
-}
-
-void TwoWire::beginTransmission(int address) {
-	beginTransmission((uint8_t) address);
 }
 
 //

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -403,7 +403,7 @@ static void Wire_Deinit(void) {
 	// and pullups were not enabled
 }
 
-TwoWire Wire = TwoWire(WireBuffers::instance(), WIRE_INTERFACE, Wire_Init, Wire_Deinit);
+TwoWire Wire = TwoWire(WireBuffers<0>::instance(), WIRE_INTERFACE, Wire_Init, Wire_Deinit);
 
 void WIRE_ISR_HANDLER(void) {
 	Wire.onService();
@@ -441,7 +441,7 @@ static void Wire1_Deinit(void) {
 	// and pullups were not enabled
 }
 
-TwoWire Wire1 = TwoWire(Wire1Buffers::instance(), WIRE1_INTERFACE, Wire1_Init, Wire1_Deinit);
+TwoWire Wire1 = TwoWire(WireBuffers<1>::instance(), WIRE1_INTERFACE, Wire1_Init, Wire1_Deinit);
 
 void WIRE1_ISR_HANDLER(void) {
 	Wire1.onService();

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -1,5 +1,5 @@
 /*
- * TwoWire.h - TWI/I2C library for Arduino Due
+ * Wire.cpp - TWI/I2C library for Arduino Due
  * Copyright (c) 2011 Cristian Maglie <c.maglie@arduino.cc>
  * All rights reserved.
  *

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -325,7 +325,7 @@ void TwoWire::onService(void) {
 				onRequestCallback();
 			else
 				// create a default 1-byte response
-				write((uint8_t) 0);
+				write(static_cast<uint8_t>(0));
 		}
 	}
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -1,5 +1,5 @@
 /*
- * TwoWire.h - TWI/I2C library for Arduino Due
+ * Wire.h - TWI/I2C library for Arduino Due
  * Copyright (c) 2011 Cristian Maglie <c.maglie@arduino.cc>
  * All rights reserved.
  *

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -27,14 +27,17 @@
 #include "Stream.h"
 #include "variant.h"
 
-#define BUFFER_LENGTH 32
-
  // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
+
+namespace TwoWireBuffers {
+  class Interface;
+}
+
 class TwoWire : public Stream {
 public:
-	TwoWire(Twi *twi, void(*begin_cb)(void), void(*end_cb)(void));
+	TwoWire(TwoWireBuffers::Interface& twbi, Twi *twi, void(*begin_cb)(void), void(*end_cb)(void));
 	void begin();
 	void begin(uint8_t);
 	void begin(int);
@@ -79,18 +82,24 @@ public:
 	void onService(void);
 
 private:
+	// The buffers to be used for this Wire object.
+	TwoWireBuffers::Interface& buffers;
+
 	// RX Buffer
-	uint8_t rxBuffer[BUFFER_LENGTH];
+  inline uint8_t* rxBuffer()const;
+  inline size_t rxBufferCapacity()const;
 	uint8_t rxBufferIndex;
 	uint8_t rxBufferLength;
 
 	// TX Buffer
 	uint8_t txAddress;
-	uint8_t txBuffer[BUFFER_LENGTH];
+  inline uint8_t* txBuffer()const;
+  inline size_t txBufferCapacity()const;
 	uint8_t txBufferLength;
 
 	// Service buffer
-	uint8_t srvBuffer[BUFFER_LENGTH];
+  inline uint8_t* srvBuffer()const;
+  inline size_t srvBufferCapacity()const;
 	uint8_t srvBufferIndex;
 	uint8_t srvBufferLength;
 
@@ -129,9 +138,13 @@ private:
 };
 
 #if WIRE_INTERFACES_COUNT > 0
+// The buffers for the Wire object
+namespace WireBuffers {extern TwoWireBuffers::Interface& instance();}
 extern TwoWire Wire;
 #endif
 #if WIRE_INTERFACES_COUNT > 1
+// The buffers for the Wire1 object
+namespace Wire1Buffers {extern TwoWireBuffers::Interface& instance();}
 extern TwoWire Wire1;
 #endif
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -81,25 +81,26 @@ public:
 
 	void onService(void);
 
+  inline size_t rxBufferCapacity()const;
+  inline size_t txBufferCapacity()const;
+  inline size_t srvBufferCapacity()const;
+
 private:
 	// The buffers to be used for this Wire object.
 	TwoWireBuffers::Interface& buffers;
 
 	// RX Buffer
   inline uint8_t* rxBuffer()const;
-  inline size_t rxBufferCapacity()const;
 	uint8_t rxBufferIndex;
 	uint8_t rxBufferLength;
 
 	// TX Buffer
 	uint8_t txAddress;
   inline uint8_t* txBuffer()const;
-  inline size_t txBufferCapacity()const;
 	uint8_t txBufferLength;
 
 	// Service buffer
   inline uint8_t* srvBuffer()const;
-  inline size_t srvBufferCapacity()const;
 	uint8_t srvBufferIndex;
 	uint8_t srvBufferLength;
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -140,12 +140,10 @@ private:
 
 #if WIRE_INTERFACES_COUNT > 0
 // The buffers for the Wire object
-namespace WireBuffers {extern TwoWireBuffers::Interface& instance();}
 extern TwoWire Wire;
 #endif
 #if WIRE_INTERFACES_COUNT > 1
 // The buffers for the Wire1 object
-namespace Wire1Buffers {extern TwoWireBuffers::Interface& instance();}
 extern TwoWire Wire1;
 #endif
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -41,14 +41,26 @@ public:
 	void end();
 	void setClock(uint32_t);
 	void beginTransmission(uint8_t);
-	void beginTransmission(int);
+  inline void beginTransmission(int address) {beginTransmission(static_cast<uint8_t>(address));}
 	uint8_t endTransmission(void);
-    uint8_t endTransmission(uint8_t);
-	uint8_t requestFrom(uint8_t, uint8_t);
-    uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
-	uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
-	uint8_t requestFrom(int, int);
-    uint8_t requestFrom(int, int, int);
+  uint8_t endTransmission(uint8_t);
+  uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
+  inline uint8_t requestFrom(uint8_t address, uint8_t quantity) {
+    return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity),
+        static_cast<uint8_t>(true));
+  }
+  inline uint8_t requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop) {
+    return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity),
+        static_cast<uint32_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(sendStop));
+  }
+  inline uint8_t requestFrom(int address, int quantity) {
+    return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity),
+        static_cast<uint8_t>(true));
+  }
+  inline uint8_t requestFrom(int address, int quantity, int sendStop) {
+    return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity),
+        static_cast<uint8_t>(sendStop));
+  }
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *, size_t);
 	virtual int available(void);
@@ -58,11 +70,11 @@ public:
 	void onReceive(void(*)(int));
 	void onRequest(void(*)(void));
 
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
-    using Print::write;
+  inline size_t write(unsigned long n) { return write(static_cast<uint8_t>(n)); }
+  inline size_t write(long n) { return write(static_cast<uint8_t>(n)); }
+  inline size_t write(unsigned int n) { return write(static_cast<uint8_t>(n)); }
+  inline size_t write(int n) { return write(static_cast<uint8_t>(n)); }
+  using Print::write;
 
 	void onService(void);
 
@@ -108,12 +120,12 @@ private:
 	TwoWireStatus status;
 
 	// TWI clock frequency
-	static const uint32_t TWI_CLOCK = 100000;
+	static constexpr uint32_t TWI_CLOCK = 100000;
 	uint32_t twiClock;
 
 	// Timeouts (
-	static const uint32_t RECV_TIMEOUT = 100000;
-	static const uint32_t XMIT_TIMEOUT = 100000;
+	static constexpr uint32_t RECV_TIMEOUT = 100000;
+	static constexpr uint32_t XMIT_TIMEOUT = 100000;
 };
 
 #if WIRE_INTERFACES_COUNT > 0


### PR DESCRIPTION
This pull request for the SAM architecture corresponds to pull request [#588](https://github.com/arduino/ArduinoCore-avr/pull/588) for the AVR architecture.

When I had the need for a bigger Wire buffer, I came up with this implementation.

- Existing sketches work like before, but just with one additional macro in the sketch, Wire will get smaller or larger buffers and will omit unnecessary buffers when possible. E.g. the receive buffer will be omitted when no receive is required. There are six example sketches available, that demonstrate how the macro works and give evidence about the customization of the buffer sizes.
Wire buffers are still allocated at compile time.

- Both TwoWire objects Wire and Wire1 are supported.

- There is also some refactoring done in regard to using C++ casts instead of C casts, making some functions inline for speed.
