### PR TITLE
Allow customization of transmit and receive buffer sizes for I2C 'Wire' and 'Wire1' objects.

### DIFF
--- a/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
+++ b/libraries/Wire/examples/master_reader_custombuffer/master_reader_custombuffer.ino
@@ -1,0 +1,94 @@
+// Wire Master Reader Custom Buffer
+
+// Demonstrates use of the Wire library with customized buffers
+// Reads data from an I2C/TWI slave device
+// Refer to the "Wire Slave Sender Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <WireBuffer.h>
+#include "Arduino.h"
+
+#define USE_WIRE1 false // Set to true for using Wire1
+
+// request 6 bytes from slave device #8
+constexpr size_t REQUESTED_BYTE_COUNT = 6;
+
+constexpr size_t RECEIVE_BUFFER_SIZE  = REQUESTED_BYTE_COUNT;
+constexpr size_t TRANSMIT_BUFFER_SIZE = 0; // There is no transmit in this sketch.
+
+#if not USE_WIRE1
+
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire.begin();        // join I2C bus (address optional for master)
+  Serial.begin(9600);  // start serial for output
+
+  // This is just for curiosity and could be removed
+  printWireBufferSize(Serial);
+}
+
+void loop() {
+  Wire.requestFrom(8, REQUESTED_BYTE_COUNT);
+
+  while (Wire.available()) { // slave may send less than requested
+    const char c = Wire.read(); // receive a byte as character
+    Serial.print(c);         // print the character
+  }
+  Serial.println();
+
+  delay(500);
+}
+
+void printWireBufferSize(Stream& stream) {
+  using namespace WireBuffer;
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+#else
+
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire1.begin();        // join I2C bus (address optional for master)
+  Serial.begin(9600);   // start serial for output
+
+  // This is just for curiosity and could be removed
+  printWire1BufferSize(Serial);
+}
+
+void loop() {
+  Wire1.requestFrom(8, REQUESTED_BYTE_COUNT);
+
+  while (Wire1.available()) { // slave may send less than requested
+    const char c = Wire1.read(); // receive a byte as character
+    Serial.print(c);         // print the character
+  }
+  Serial.println();
+
+  delay(500);
+}
+
+void printWire1BufferSize(Stream& stream) {
+  using namespace Wire1Buffer;
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+#endif

--- a/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
+++ b/libraries/Wire/examples/master_writer_custombuffer/master_writer_custombuffer.ino
@@ -1,0 +1,94 @@
+// Wire Master Writer Custom Buffer
+
+// Demonstrates use of the Wire library with customized buffers
+// Writes data to an I2C/TWI slave device
+// Refer to the "Wire Slave Receiver Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <WireBuffer.h>
+#include "Arduino.h"
+
+#define USE_WIRE1 false // Set to true for using Wire1
+
+// The following text will not fit into the default buffer of 32 bytes.
+static const char text[] = "You really won't believe it, but x is ";
+
+constexpr size_t RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
+constexpr size_t TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
+
+#if not USE_WIRE1
+
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire.begin(); // join I2C bus (address optional for master)
+
+  // This is just for curiosity and could be removed
+  Serial.begin(9600);   // start serial for output
+  printWireBufferSize(Serial);
+}
+
+static byte x = 0;
+
+void loop() {
+  Wire.beginTransmission(8); // transmit to device #8
+  Wire.write(text);          // sends multiple bytes
+  Wire.write(x);             // sends one byte
+  Wire.endTransmission();    // stop transmitting
+
+  x++;
+  delay(500);
+}
+
+void printWireBufferSize(Stream& stream) {
+  using namespace WireBuffer;
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+#else
+
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+void setup() {
+  Wire1.begin(); // join I2C bus (address optional for master)
+
+  // This is just for curiosity and could be removed
+  Serial.begin(9600);   // start serial for output
+  printWire1BufferSize(Serial);
+}
+
+static byte x = 0;
+
+void loop() {
+  Wire1.beginTransmission(8); // transmit to device #8
+  Wire1.write(text);          // sends multiple bytes
+  Wire1.write(x);             // sends one byte
+  Wire1.endTransmission();    // stop transmitting
+
+  x++;
+  delay(500);
+}
+
+void printWire1BufferSize(Stream& stream) {
+  using namespace Wire1Buffer;
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+#endif

--- a/libraries/Wire/examples/slave_receiver_Wire1Wire_connected/slave_receiver_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_receiver_Wire1Wire_connected/slave_receiver_Wire1Wire_connected.ino
@@ -1,0 +1,94 @@
+// Wire1 connnected to Wire. (scl <-> scl1, sda <-> sda1)
+
+// Demonstrates use of the Wire library on a single Arduino board
+// with 2 Wire interfaces (like Arduino Due).
+// Uses the option of customizing the buffers.
+//
+// Wire data to an I2C/TWI slave device
+// Wire1 receives data as an I2C/TWI slave device
+
+// Created 02 Jan 2025
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <WireBuffer.h>
+#include "Arduino.h"
+
+static_assert(WIRE_INTERFACES_COUNT > 1, "You need two I2C interfaces on the Arduino board to run this sketch");
+
+static const char text[] = "You really won't believe it, but x is ";
+
+// Wire is the master writer
+constexpr size_t M_RECEIVE_BUFFER_SIZE  = 0;  // There is no receive in this sketch.
+constexpr size_t M_TRANSMIT_BUFFER_SIZE = 42; // Enhance the buffer to 42 characters.
+SET_Wire_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+// Wire1 is the slave receiver
+constexpr size_t S_RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
+constexpr size_t S_TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
+SET_Wire1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Serial.begin(9600);            // start serial for output
+  Wire.begin();                  // master joins I2C bus (address optional for master)
+  Wire1.begin(8);                // slave joins I2C bus with address #8
+  Wire1.onReceive(receiveEvent); // register event
+
+  // This is just for curiosity and could be removed
+  printWireBufferSize(Serial);
+  printWire1BufferSize(Serial);
+}
+
+static byte x = 0;
+
+void loop() {
+  Wire.beginTransmission(8); // transmit to device #8
+  Wire.write(text);          // sends multiple bytes
+  Wire.write(x);             // sends one byte
+  Wire.endTransmission();    // stop transmitting
+
+  x++;
+  delay(500);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+//
+// Hint: This function is called within an interrupt context.
+// That means, that there must be enough space in the Serial output
+// buffer for the characters to be printed. Otherwise the
+// Serial.print() call will lock up.
+void receiveEvent(int howMany) {
+  while (1 < Wire1.available()) { // loop through all but the last
+    const char c = Wire1.read();  // receive byte as a character
+    Serial.print(c);              // print the character
+  }
+  const int x = Wire1.read();     // receive byte as an integer
+  Serial.println(x);              // print the integer
+}
+
+void printWireBufferSize(Stream& stream) {
+  using namespace WireBuffer;
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+  delay(250); // Give time to free up Serial output buffer.
+}
+
+void printWire1BufferSize(Stream& stream) {
+  using namespace Wire1Buffer;
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+  delay(250); // Give time to free up Serial output buffer.
+}

--- a/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
+++ b/libraries/Wire/examples/slave_receiver_custombuffer/slave_receiver_custombuffer.ino
@@ -1,0 +1,111 @@
+// Wire Slave Receiver Custom Buffer
+
+// Demonstrates use of the Wire library with customized buffers
+// Receives data as an I2C/TWI slave device
+// Refer to the "Wire Master Writer Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <WireBuffer.h>
+#include "Arduino.h"
+
+#define USE_WIRE1 false // Set to true for using Wire1
+
+constexpr size_t RECEIVE_BUFFER_SIZE  = 42; // Be able receive up to 42 characters in one message.
+constexpr size_t TRANSMIT_BUFFER_SIZE = 0;  // There is no transmit in this sketch.
+
+#if not USE_WIRE1
+
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Wire.begin(8);                // join I2C bus with address #8
+  Wire.onReceive(receiveEvent); // register event
+  Serial.begin(9600);           // start serial for output
+
+  // This is just for curiosity and could be removed
+  printWireBufferSize(Serial);
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+//
+// Hint: This function is called within an interrupt context.
+// That means, that there must be enough space in the Serial output
+// buffer for the characters to be printed. Otherwise the
+// Serial.print() call will lock up.
+void receiveEvent(int howMany) {
+  while (1 < Wire.available()) { // loop through all but the last
+    const char c = Wire.read();  // receive byte as a character
+    Serial.print(c);             // print the character
+  }
+  const int x = Wire.read();     // receive byte as an integer
+  Serial.println(x);             // print the integer
+}
+
+void printWireBufferSize(Stream& stream) {
+  using namespace WireBuffer;
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+  delay(250); // Give time to free up Serial output buffer.
+}
+
+#else
+
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Wire1.begin(8);                // join I2C bus with address #8
+  Wire1.onReceive(receiveEvent); // register event
+  Serial.begin(9600);            // start serial for output
+
+  // This is just for curiosity and could be removed
+  printWire1BufferSize(Serial);
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+//
+// Hint: This function is called within an interrupt context.
+// That means, that there must be enough space in the Serial output
+// buffer for the characters to be printed. Otherwise the
+// Serial.print() call will lock up.
+void receiveEvent(int howMany) {
+  while (1 < Wire1.available()) { // loop through all but the last
+    const char c = Wire1.read();  // receive byte as a character
+    Serial.print(c);              // print the character
+  }
+  const int x = Wire1.read();     // receive byte as an integer
+  Serial.println(x);              // print the integer
+}
+
+void printWire1BufferSize(Stream& stream) {
+  using namespace Wire1Buffer;
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+  delay(250); // Give time to free up Serial output buffer.
+}
+
+#endif

--- a/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
+++ b/libraries/Wire/examples/slave_sender_Wire1Wire_connected/slave_sender_Wire1Wire_connected.ino
@@ -1,0 +1,83 @@
+// Wire1 connnected to Wire. (scl <-> scl1, sda <-> sda1)
+
+// Demonstrates use of the Wire library on a single Arduino board
+// with 2 Wire interfaces (like Arduino Due).
+// Uses the option of customizing the buffers.
+//
+// Wire reads data from an I2C/TWI slave device
+// Wire1 sends data as an I2C/TWI slave device
+
+// Created 02 Jan 2025
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <WireBuffer.h>
+#include "Arduino.h"
+
+static_assert(WIRE_INTERFACES_COUNT > 1, "You need two I2C interfaces on the Arduino board to run this sketch");
+
+static const char text[] = "hello "; // respond with message of 6 bytes
+
+// Wire is the master reader
+constexpr size_t M_RECEIVE_BUFFER_SIZE  = sizeof(text)-1; // Don't need a byte for the \0
+constexpr size_t M_TRANSMIT_BUFFER_SIZE = 0; // There is no transmit in this sketch.
+SET_Wire_BUFFERS(M_RECEIVE_BUFFER_SIZE, M_TRANSMIT_BUFFER_SIZE,
+    true /* master buffers needed */, false /* no slave buffers needed */ );
+
+// Wire1 is the slave sender
+constexpr size_t S_RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
+constexpr size_t S_TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
+SET_Wire1_BUFFERS(S_RECEIVE_BUFFER_SIZE, S_TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Serial.begin(9600);            // start serial for output
+  Wire.begin();                  // master joins I2C bus (address optional for master)
+  Wire1.begin(8);                // slave joins I2C bus with address #8
+  Wire1.onRequest(requestEvent); // register slave event
+
+  // This is just for curiosity and could be removed
+  printWireBufferSize(Serial);
+  printWire1BufferSize(Serial);
+}
+
+void loop() {
+  Wire.requestFrom(8, M_RECEIVE_BUFFER_SIZE);
+
+  while (Wire.available()) {
+    const char c = Wire.read(); // receive a byte as character
+    Serial.print(c);            // print the character
+  }
+  Serial.println();
+
+  delay(500);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire1.write(text);
+  // as expected by master
+}
+
+void printWireBufferSize(Stream& stream) {
+  using namespace WireBuffer;
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+void printWire1BufferSize(Stream& stream) {
+  using namespace Wire1Buffer;
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}

--- a/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
+++ b/libraries/Wire/examples/slave_sender_custombuffer/slave_sender_custombuffer.ino
@@ -1,0 +1,93 @@
+// Wire Slave Sender Custom Buffer
+
+// Demonstrates use of the Wire library with customized buffers
+// Sends data as an I2C/TWI slave device
+// Refer to the "Wire Master Reader Custom Buffer" example for use with this
+
+// Created 31 Dec 2024
+
+// This example code is in the public domain.
+
+
+#include <Wire.h>
+#include <WireBuffer.h>
+#include "Arduino.h"
+
+#define USE_WIRE1 false // Set to true for using Wire1
+
+static const char text[] = "hello "; // respond with message of 6 bytes
+
+constexpr size_t RECEIVE_BUFFER_SIZE  = 0; // There is no receive in this sketch.
+constexpr size_t TRANSMIT_BUFFER_SIZE = sizeof(text)-1; // Don't need a byte for the \0
+
+#if not USE_WIRE1
+
+SET_Wire_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Wire.begin(8);                // join I2C bus with address #8
+  Wire.onRequest(requestEvent); // register event
+
+  // This is just for curiosity and could be removed
+  Serial.begin(9600);
+  printWireBufferSize(Serial);
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire.write(text);
+  // as expected by master
+}
+
+void printWireBufferSize(Stream& stream) {
+  using namespace WireBuffer;
+  stream.print("Wire receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+#else
+
+SET_Wire1_BUFFERS(RECEIVE_BUFFER_SIZE, TRANSMIT_BUFFER_SIZE,
+    false /* no master buffers needed */, true /* slave buffers needed */ );
+
+void setup() {
+  Wire1.begin(8);                // join I2C bus with address #8
+  Wire1.onRequest(requestEvent); // register event
+
+  // This is just for curiosity and could be removed
+  Serial.begin(9600);
+  printWire1BufferSize(Serial);
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire1.write(text);
+  // as expected by master
+}
+
+void printWire1BufferSize(Stream& stream) {
+  using namespace Wire1Buffer;
+  stream.print("Wire1 receive buffer size is ");
+  stream.println(buffers.RX_BUFFER_SIZE);
+  stream.print("Wire1 transmit buffer size is ");
+  stream.println(buffers.TX_BUFFER_SIZE);
+  stream.print("Wire1 service buffer size is ");
+  stream.println(buffers.SRV_BUFFER_SIZE);
+}
+
+#endif

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -186,32 +186,12 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 	return readed;
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop) {
-	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint32_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(sendStop));
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity) {
-	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint8_t>(true));
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity) {
-	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint8_t>(true));
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop) {
-	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint8_t>(sendStop));
-}
-
 void TwoWire::beginTransmission(uint8_t address) {
 	status = MASTER_SEND;
 
 	// save address of target and empty buffer
 	txAddress = address;
 	txBufferLength = 0;
-}
-
-void TwoWire::beginTransmission(int address) {
-	beginTransmission(static_cast<uint8_t>(address));
 }
 
 //

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -142,7 +142,7 @@ void TwoWire::begin(uint8_t address) {
 }
 
 void TwoWire::begin(int address) {
-	begin((uint8_t) address);
+	begin(static_cast<uint8_t>(address));
 }
 
 void TwoWire::end(void) {
@@ -187,19 +187,19 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 }
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint32_t) 0, (uint8_t) 0, (uint8_t) sendStop);
+	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint32_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(sendStop));
 }
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint8_t) true);
+	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint8_t>(true));
 }
 
 uint8_t TwoWire::requestFrom(int address, int quantity) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint8_t) true);
+	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint8_t>(true));
 }
 
 uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop) {
-	return requestFrom((uint8_t) address, (uint8_t) quantity, (uint8_t) sendStop);
+	return requestFrom(static_cast<uint8_t>(address), static_cast<uint8_t>(quantity), static_cast<uint8_t>(sendStop));
 }
 
 void TwoWire::beginTransmission(uint8_t address) {
@@ -211,7 +211,7 @@ void TwoWire::beginTransmission(uint8_t address) {
 }
 
 void TwoWire::beginTransmission(int address) {
-	beginTransmission((uint8_t) address);
+	beginTransmission(static_cast<uint8_t>(address));
 }
 
 //
@@ -346,7 +346,7 @@ void TwoWire::onService(void) {
 				onRequestCallback();
 			else
 				// create a default 1-byte response
-				write((uint8_t) 0);
+				write(static_cast<uint8_t>(0));
 		}
 	}
 
@@ -355,7 +355,7 @@ void TwoWire::onService(void) {
 			// Copy data into rxBuffer
 			// (allows to receive another packet while the
 			// user program reads actual data)
-			for (uint8_t i = 0; i < srvBufferLength; ++i)
+			for (size_t i = 0; i < srvBufferLength; ++i)
 				rxBuffer()[i] = srvBuffer()[i];
 			rxBufferIndex = 0;
 			rxBufferLength = srvBufferLength;

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -52,26 +52,26 @@ public:
 	uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
 	uint8_t requestFrom(int, int);
     uint8_t requestFrom(int, int, int);
-	virtual size_t write(uint8_t);
-	virtual size_t write(const uint8_t *, size_t);
-	virtual int available(void);
-	virtual int read(void);
-	virtual int peek(void);
-	virtual void flush(void);
+	size_t write(uint8_t) override;
+	size_t write(const uint8_t *, size_t) override;
+	int available(void) override;
+	int read(void) override;
+	int peek(void) override;
+	void flush(void) override;
 	void onReceive(void(*)(int));
 	void onRequest(void(*)(void));
 
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
+    inline size_t write(unsigned long n) { return write(static_cast<uint8_t>(n)); }
+    inline size_t write(long n) { return write(static_cast<uint8_t>(n)); }
+    inline size_t write(unsigned int n) { return write(static_cast<uint8_t>(n)); }
+    inline size_t write(int n) { return write(static_cast<uint8_t>(n)); }
     using Print::write;
 
 	void onService(void);
 
 private:
+	// Container of rxBuffer, txBuffer and srvBuffer
 	const TwoWireBuffer::Buffers& buffers;
-
 
 	// RX Buffer
   inline uint8_t* rxBuffer() const;
@@ -93,13 +93,13 @@ private:
 	void (*onReceiveCallback)(int);
 
 	// Called before initialization
-	void (*onBeginCallback)(void);
+	void (*const onBeginCallback)(void);
 
 	// Called after deinitialization
-	void (*onEndCallback)(void);
+	void (*const onEndCallback)(void);
 
 	// TWI instance
-	Twi *twi;
+	Twi * const twi;
 
 	// TWI state
 	enum TwoWireStatus {
@@ -114,12 +114,12 @@ private:
 	TwoWireStatus status;
 
 	// TWI clock frequency
-	static const uint32_t TWI_CLOCK = 100000;
+	static constexpr uint32_t TWI_CLOCK = 100000;
 	uint32_t twiClock;
 
 	// Timeouts (
-	static const uint32_t RECV_TIMEOUT = 100000;
-	static const uint32_t XMIT_TIMEOUT = 100000;
+	static constexpr uint32_t RECV_TIMEOUT = 100000;
+	static constexpr uint32_t XMIT_TIMEOUT = 100000;
 };
 
 #if WIRE_INTERFACES_COUNT > 0

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -23,18 +23,21 @@
 
 // Include Atmel CMSIS driver
 #include <include/twi.h>
-
 #include "Stream.h"
 #include "variant.h"
 
-#define BUFFER_LENGTH 32
+// Forward declaration of TwoWireBuffer::Buffers
+namespace TwoWireBuffer {
+  struct Buffers;
+}
 
  // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
 class TwoWire : public Stream {
 public:
-	TwoWire(Twi *twi, void(*begin_cb)(void), void(*end_cb)(void));
+	TwoWire(const TwoWireBuffer::Buffers& _buffers,
+	    Twi *twi, void(*begin_cb)(void), void(*end_cb)(void));
 	void begin();
 	void begin(uint8_t);
 	void begin(int);
@@ -67,18 +70,21 @@ public:
 	void onService(void);
 
 private:
+	const TwoWireBuffer::Buffers& buffers;
+
+
 	// RX Buffer
-	uint8_t rxBuffer[BUFFER_LENGTH];
+  inline uint8_t* rxBuffer() const;
 	uint8_t rxBufferIndex;
 	uint8_t rxBufferLength;
 
 	// TX Buffer
+  inline uint8_t* txBuffer() const;
 	uint8_t txAddress;
-	uint8_t txBuffer[BUFFER_LENGTH];
 	uint8_t txBufferLength;
 
 	// Service buffer
-	uint8_t srvBuffer[BUFFER_LENGTH];
+	inline uint8_t* srvBuffer() const;
 	uint8_t srvBufferIndex;
 	uint8_t srvBufferLength;
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -44,14 +44,29 @@ public:
 	void end();
 	void setClock(uint32_t);
 	void beginTransmission(uint8_t);
-	void beginTransmission(int);
+  inline void beginTransmission(int address) {
+    beginTransmission(static_cast<uint8_t>(address));
+  }
 	uint8_t endTransmission(void);
-    uint8_t endTransmission(uint8_t);
-	uint8_t requestFrom(uint8_t, uint8_t);
-    uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+  uint8_t endTransmission(uint8_t);
 	uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
-	uint8_t requestFrom(int, int);
-    uint8_t requestFrom(int, int, int);
+  inline uint8_t requestFrom(uint8_t address, uint8_t quantity) {
+    return requestFrom(static_cast<uint8_t>(address),
+        static_cast<uint8_t>(quantity), static_cast<uint8_t>(true));
+  }
+  inline uint8_t requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop) {
+    return requestFrom(static_cast<uint8_t>(address),
+        static_cast<uint8_t>(quantity), static_cast<uint32_t>(0),
+        static_cast<uint8_t>(0), static_cast<uint8_t>(sendStop));
+  }
+  inline uint8_t requestFrom(int address, int quantity) {
+    return requestFrom(static_cast<uint8_t>(address),
+        static_cast<uint8_t>(quantity), static_cast<uint8_t>(true));
+  }
+  inline uint8_t requestFrom(int address, int quantity, int sendStop) {
+    return requestFrom(static_cast<uint8_t>(address),
+        static_cast<uint8_t>(quantity), static_cast<uint8_t>(sendStop));
+  }
 	size_t write(uint8_t) override;
 	size_t write(const uint8_t *, size_t) override;
 	int available(void) override;
@@ -61,11 +76,11 @@ public:
 	void onReceive(void(*)(int));
 	void onRequest(void(*)(void));
 
-    inline size_t write(unsigned long n) { return write(static_cast<uint8_t>(n)); }
-    inline size_t write(long n) { return write(static_cast<uint8_t>(n)); }
-    inline size_t write(unsigned int n) { return write(static_cast<uint8_t>(n)); }
-    inline size_t write(int n) { return write(static_cast<uint8_t>(n)); }
-    using Print::write;
+  inline size_t write(unsigned long n) { return write(static_cast<uint8_t>(n)); }
+  inline size_t write(long n) { return write(static_cast<uint8_t>(n)); }
+  inline size_t write(unsigned int n) { return write(static_cast<uint8_t>(n)); }
+  inline size_t write(int n) { return write(static_cast<uint8_t>(n)); }
+  using Print::write;
 
 	void onService(void);
 

--- a/libraries/Wire/src/WireBuffer.cpp
+++ b/libraries/Wire/src/WireBuffer.cpp
@@ -1,0 +1,49 @@
+/*
+  WireBuffer.cpp - TWI/I2C library for Arduino & Wiring
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <stdint.h>
+#include <stddef.h>
+#include "variant.h"
+#include "WireBuffer.h"
+
+#if WIRE_INTERFACES_COUNT > 0
+// Define default buffers as weak buffers
+namespace WireBuffer {
+  extern __attribute__((weak)) const Buffers buffers {
+    WIRE_BUFFER_DEFAULT_SIZE, WIRE_BUFFER_DEFAULT_SIZE, WIRE_BUFFER_DEFAULT_SIZE
+    , srvBuffer, rxBuffer, txBuffer
+  };
+  __attribute__((weak)) uint8_t srvBuffer[WIRE_BUFFER_DEFAULT_SIZE];
+  __attribute__((weak)) uint8_t  rxBuffer[WIRE_BUFFER_DEFAULT_SIZE];
+  __attribute__((weak)) uint8_t  txBuffer[WIRE_BUFFER_DEFAULT_SIZE];
+}
+#endif
+
+#if WIRE_INTERFACES_COUNT > 1
+// Define default buffers as weak buffers
+namespace Wire1Buffer {
+  extern __attribute__((weak)) const Buffers buffers {
+    WIRE_BUFFER_DEFAULT_SIZE, WIRE_BUFFER_DEFAULT_SIZE, WIRE_BUFFER_DEFAULT_SIZE
+    , srvBuffer, rxBuffer, txBuffer
+  };
+  __attribute__((weak)) uint8_t srvBuffer[WIRE_BUFFER_DEFAULT_SIZE];
+  __attribute__((weak)) uint8_t  rxBuffer[WIRE_BUFFER_DEFAULT_SIZE];
+  __attribute__((weak)) uint8_t  txBuffer[WIRE_BUFFER_DEFAULT_SIZE];
+}
+#endif

--- a/libraries/Wire/src/WireBuffer.h
+++ b/libraries/Wire/src/WireBuffer.h
@@ -1,0 +1,80 @@
+/*
+  WireBuffer.h - TWI/I2C library for Arduino & Wiring
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#ifndef Wire_WireBuffer_h_
+#define Wire_WireBuffer_h_
+
+#include <stdint.h>
+#include <stddef.h>
+#include "variant.h"
+
+
+// Use extra namespace to avoid collision with other symbols
+namespace TwoWireBuffer {
+  // Declare twi buffers
+  typedef size_t bufferSize_t;
+  constexpr bufferSize_t WIRE_BUFFER_DEFAULT_SIZE = 32;
+
+  struct Buffers {
+    bufferSize_t SRV_BUFFER_SIZE;
+    bufferSize_t RX_BUFFER_SIZE;
+    bufferSize_t TX_BUFFER_SIZE;
+    uint8_t* const srvBuffer;
+    uint8_t* const rxBuffer;
+    uint8_t* const txBuffer;
+  };
+}
+
+#define SET_TwoWire_BUFFERS(rxBufferSize, txBufferSize) \
+    constexpr bufferSize_t srvBufferSize = (rxBufferSize) > (txBufferSize) ? (rxBufferSize) : (txBufferSize); \
+    const Buffers buffers { (srvBufferSize), (rxBufferSize), (txBufferSize), srvBuffer, rxBuffer, txBuffer }; \
+    uint8_t srvBuffer[srvBufferSize]; \
+    uint8_t  rxBuffer[(rxBufferSize)];\
+    uint8_t  txBuffer[(txBufferSize)];
+
+
+#if WIRE_INTERFACES_COUNT > 0
+  namespace WireBuffer {
+    using namespace TwoWireBuffer;
+    extern const Buffers buffers;
+    extern uint8_t srvBuffer[];
+    extern uint8_t  rxBuffer[];
+    extern uint8_t  txBuffer[];
+  }
+
+  #define SET_Wire_BUFFERS(rxBufferSize, txBufferSize, enableMaster, enableSlave) \
+        namespace WireBuffer {SET_TwoWire_BUFFERS(rxBufferSize, txBufferSize)}
+#endif // WIRE_INTERFACES_COUNT > 0
+
+#if WIRE_INTERFACES_COUNT > 1
+  namespace Wire1Buffer {
+    using namespace TwoWireBuffer;
+    extern const Buffers buffers;
+    extern uint8_t srvBuffer[];
+    extern uint8_t  rxBuffer[];
+    extern uint8_t  txBuffer[];
+  }
+
+  #define SET_Wire1_BUFFERS(rxBufferSize, txBufferSize, enableMaster, enableSlave) \
+        namespace Wire1Buffer {SET_TwoWire_BUFFERS(rxBufferSize, txBufferSize)}
+#endif // WIRE_INTERFACES_COUNT > 1
+
+#endif /* Wire_WireBuffer_h_ */


### PR DESCRIPTION
This pull request for the SAM architecture corresponds to pull request [#589](https://github.com/arduino/ArduinoCore-avr/pull/589) for the AVR architecture.

When I had the need for a bigger Wire buffer, I came up with this implementation.

- Existing sketches work like before, but just with one additional macro in the sketch, Wire will get smaller or larger buffers and will omit unnecessary buffers when possible. E.g. the receive buffer will be omitted when no receive is required. There are six example sketches available, that demonstrate how the macro works and give evidence about the customization of the buffer sizes.
Wire buffers are still allocated at compile time.

- Both TwoWire objects Wire and Wire1 are supported.

- There is also some refactoring done in regard to using C++ casts instead of C casts, making some functions inline for speed and code size.