### PR TITLE
Added functions RTC_GetTimeAndDate() and RTC_SetTimeAndDate(

### DIFF
--- a/system/libsam/include/rtc.h
+++ b/system/libsam/include/rtc.h
@@ -89,6 +89,10 @@ extern void RTC_ClearSCCR( Rtc* pRtc, uint32_t dwMask ) ;
 
 extern uint32_t RTC_GetSR( Rtc* pRtc, uint32_t dwMask ) ;
 
+extern void RTC_GetTimeAndDate( Rtc* pRtc, uint8_t *pucHour, uint8_t *pucMinute, uint8_t *pucSecond, uint16_t *pwYear, uint8_t *pucMonth, uint8_t *pucDay, uint8_t *pucWeek );
+
+extern int RTC_SetTimeAndDate( Rtc* pRtc, uint8_t ucHour, uint8_t ucMinute, uint8_t ucSecond, uint16_t wYear, uint8_t ucMonth, uint8_t ucDay, uint8_t ucWeek );
+
 #ifdef __cplusplus
 }
 #endif

--- a/system/libsam/include/rtc.h
+++ b/system/libsam/include/rtc.h
@@ -40,22 +40,7 @@
 /*----------------------------------------------------------------------------
  *        Headers
  *----------------------------------------------------------------------------*/
-#include "../chip.h"
-
 #include <stdint.h>
-
-/*----------------------------------------------------------------------------
- *        Definitions
- *----------------------------------------------------------------------------*/
-
-#define RTC_HOUR_BIT_LEN_MASK   0x3F
-#define RTC_MIN_BIT_LEN_MASK    0x7F
-#define RTC_SEC_BIT_LEN_MASK    0x7F
-#define RTC_CENT_BIT_LEN_MASK   0x7F
-#define RTC_YEAR_BIT_LEN_MASK   0xFF
-#define RTC_MONTH_BIT_LEN_MASK  0x1F
-#define RTC_DATE_BIT_LEN_MASK   0x3F
-#define RTC_WEEK_BIT_LEN_MASK   0x07
 
 /*----------------------------------------------------------------------------
  *        Exported functions

--- a/system/libsam/include/rtc.h
+++ b/system/libsam/include/rtc.h
@@ -62,13 +62,13 @@ extern int RTC_SetTime( Rtc* pRtc, uint8_t ucHour, uint8_t ucMinute, uint8_t ucS
 
 extern void RTC_GetTime( Rtc* pRtc, uint8_t *pucHour, uint8_t *pucMinute, uint8_t *pucSecond ) ;
 
-extern int RTC_SetTimeAlarm( Rtc* pRtc, uint8_t *pucHour, uint8_t *pucMinute, uint8_t *pucSecond ) ;
+extern int RTC_SetTimeAlarm( Rtc* pRtc, const uint8_t *pucHour, const uint8_t *pucMinute, const uint8_t *pucSecond ) ;
 
 extern void RTC_GetDate( Rtc* pRtc, uint16_t *pwYear, uint8_t *pucMonth, uint8_t *pucDay, uint8_t *pucWeek ) ;
 
 extern int RTC_SetDate( Rtc* pRtc, uint16_t wYear, uint8_t ucMonth, uint8_t ucDay, uint8_t ucWeek ) ;
 
-extern int RTC_SetDateAlarm( Rtc* pRtc, uint8_t *pucMonth, uint8_t *pucDay ) ;
+extern int RTC_SetDateAlarm( Rtc* pRtc, const uint8_t *pucMonth, const uint8_t *pucDay ) ;
 
 extern void RTC_ClearSCCR( Rtc* pRtc, uint32_t dwMask ) ;
 

--- a/system/libsam/source/rtc.c
+++ b/system/libsam/source/rtc.c
@@ -167,6 +167,42 @@ static uint32_t calculate_dwDate( Rtc* pRtc, uint16_t wYear, uint8_t ucMonth, ui
             (ucDay_bcd << 24);
 }
 
+/**
+ * \brief Convert the RTC_TIMR bcd format to hour, minute and second.
+ *
+ * \param pucHour    If not null, current hour is stored in this variable.
+ * \param pucMinute  If not null, current minute is stored in this variable.
+ * \param pucSecond  If not null, current second is stored in this variable.
+ */
+static void dwTime2time( uint32_t dwTime, uint8_t *pucHour, uint8_t *pucMinute, uint8_t *pucSecond )
+{
+    /* Hour */
+    if ( pucHour )
+    {
+        *pucHour = ((dwTime & 0x00300000) >> 20) * 10
+                 + ((dwTime & 0x000F0000) >> 16);
+
+        if ( (dwTime & RTC_TIMR_AMPM) == RTC_TIMR_AMPM )
+        {
+            *pucHour += 12 ;
+        }
+    }
+
+    /* Minute */
+    if ( pucMinute )
+    {
+        *pucMinute = ((dwTime & 0x00007000) >> 12) * 10
+                   + ((dwTime & 0x00000F00) >> 8);
+    }
+
+    /* Second */
+    if ( pucSecond )
+    {
+        *pucSecond = ((dwTime & 0x00000070) >> 4) * 10
+                   + (dwTime & 0x0000000F);
+    }
+}
+
 /*----------------------------------------------------------------------------
  *        Exported functions
  *----------------------------------------------------------------------------*/
@@ -262,40 +298,14 @@ extern int RTC_SetTime( Rtc* pRtc, uint8_t ucHour, uint8_t ucMinute, uint8_t ucS
  */
 extern void RTC_GetTime( Rtc* pRtc, uint8_t *pucHour, uint8_t *pucMinute, uint8_t *pucSecond )
 {
-    uint32_t dwTime ;
-
     /* Get current RTC time */
-    dwTime = pRtc->RTC_TIMR ;
+    uint32_t dwTime = pRtc->RTC_TIMR ;
     while ( dwTime != pRtc->RTC_TIMR )
     {
         dwTime = pRtc->RTC_TIMR ;
     }
 
-    /* Hour */
-    if ( pucHour )
-    {
-        *pucHour = ((dwTime & 0x00300000) >> 20) * 10
-                 + ((dwTime & 0x000F0000) >> 16);
-
-        if ( (dwTime & RTC_TIMR_AMPM) == RTC_TIMR_AMPM )
-        {
-            *pucHour += 12 ;
-        }
-    }
-
-    /* Minute */
-    if ( pucMinute )
-    {
-        *pucMinute = ((dwTime & 0x00007000) >> 12) * 10
-                   + ((dwTime & 0x00000F00) >> 8);
-    }
-
-    /* Second */
-    if ( pucSecond )
-    {
-        *pucSecond = ((dwTime & 0x00000070) >> 4) * 10
-                   + (dwTime & 0x0000000F);
-    }
+    dwTime2time( dwTime, pucHour, pucMinute, pucSecond ) ;
 }
 
 /**

--- a/system/libsam/source/rtc.c
+++ b/system/libsam/source/rtc.c
@@ -203,6 +203,44 @@ static void dwTime2time( uint32_t dwTime, uint8_t *pucHour, uint8_t *pucMinute, 
     }
 }
 
+/**
+ * \brief Convert the RTC_CALR bcd format to year, month, day, week.
+ *
+ * \param pYwear  Current year (optional).
+ * \param pucMonth  Current month (optional).
+ * \param pucDay  Current day (optional).
+ * \param pucWeek  Current day in current week (optional).
+ */
+extern void dwDate2date( uint32_t dwDate, uint16_t *pwYear, uint8_t *pucMonth, uint8_t *pucDay, uint8_t *pucWeek )
+{
+    /* Retrieve year */
+    if ( pwYear )
+    {
+        *pwYear = (((dwDate  >> 4) & 0x7) * 1000)
+                 + ((dwDate & 0xF) * 100)
+                 + (((dwDate >> 12) & 0xF) * 10)
+                 + ((dwDate >> 8) & 0xF);
+    }
+
+    /* Retrieve month */
+    if ( pucMonth )
+    {
+        *pucMonth = (((dwDate >> 20) & 1) * 10) + ((dwDate >> 16) & 0xF);
+    }
+
+    /* Retrieve day */
+    if ( pucDay )
+    {
+        *pucDay = (((dwDate >> 28) & 0x3) * 10) + ((dwDate >> 24) & 0xF);
+    }
+
+    /* Retrieve week */
+    if ( pucWeek )
+    {
+        *pucWeek = ((dwDate >> 21) & 0x7);
+    }
+}
+
 /*----------------------------------------------------------------------------
  *        Exported functions
  *----------------------------------------------------------------------------*/
@@ -369,32 +407,7 @@ extern void RTC_GetDate( Rtc* pRtc, uint16_t *pwYear, uint8_t *pucMonth, uint8_t
     }
     while ( dwDate != pRtc->RTC_CALR ) ;
 
-    /* Retrieve year */
-    if ( pwYear )
-    {
-        *pwYear = (((dwDate  >> 4) & 0x7) * 1000)
-                 + ((dwDate & 0xF) * 100)
-                 + (((dwDate >> 12) & 0xF) * 10)
-                 + ((dwDate >> 8) & 0xF);
-    }
-
-    /* Retrieve month */
-    if ( pucMonth )
-    {
-        *pucMonth = (((dwDate >> 20) & 1) * 10) + ((dwDate >> 16) & 0xF);
-    }
-
-    /* Retrieve day */
-    if ( pucDay )
-    {
-        *pucDay = (((dwDate >> 28) & 0x3) * 10) + ((dwDate >> 24) & 0xF);
-    }
-
-    /* Retrieve week */
-    if ( pucWeek )
-    {
-        *pucWeek = ((dwDate >> 21) & 0x7);
-    }
+    dwDate2date( dwDate, pwYear, *pucMonth, *pucDay, *pucWeek ) ;
 }
 
 /**

--- a/system/libsam/source/rtc.c
+++ b/system/libsam/source/rtc.c
@@ -373,7 +373,7 @@ extern void RTC_GetTime( Rtc* pRtc, uint8_t *pucHour, uint8_t *pucMinute, uint8_
  *
  * \return 0 success, 1 fail to set
  */
-extern int RTC_SetTimeAlarm( Rtc* pRtc, uint8_t *pucHour, uint8_t *pucMinute, uint8_t *pucSecond )
+extern int RTC_SetTimeAlarm( Rtc* pRtc, const uint8_t *pucHour, const uint8_t *pucMinute, const uint8_t *pucSecond )
 {
     uint32_t dwAlarm=0 ;
 
@@ -468,7 +468,7 @@ extern int RTC_SetDate( Rtc* pRtc, uint16_t wYear, uint8_t ucMonth, uint8_t ucDa
  *
  * \return 0 success, 1 fail to set
  */
-extern int RTC_SetDateAlarm( Rtc* pRtc, uint8_t *pucMonth, uint8_t *pucDay )
+extern int RTC_SetDateAlarm( Rtc* pRtc, const uint8_t *pucMonth, const uint8_t *pucDay )
 {
     uint32_t dwAlarm ;
 

--- a/system/libsam/source/rtc.c
+++ b/system/libsam/source/rtc.c
@@ -179,7 +179,7 @@ extern int RTC_SetTime( Rtc* pRtc, uint8_t ucHour, uint8_t ucMinute, uint8_t ucS
         return 1 ;
     }
 
-    dwTime = ucSec_bcd | (ucMin_bcd << 8) | (ucHour_bcd<<16) ;
+    dwTime |= ucSec_bcd | (ucMin_bcd << 8) | (ucHour_bcd<<16) ;
 
     pRtc->RTC_CR |= RTC_CR_UPDTIM ;
     while ((pRtc->RTC_SR & RTC_SR_ACKUPD) != RTC_SR_ACKUPD) ;

--- a/system/libsam/source/rtc.c
+++ b/system/libsam/source/rtc.c
@@ -84,6 +84,19 @@
 #include <assert.h>
 
 /*----------------------------------------------------------------------------
+ *        Definitions
+ *----------------------------------------------------------------------------*/
+
+#define RTC_HOUR_BIT_LEN_MASK   0x3F
+#define RTC_MIN_BIT_LEN_MASK    0x7F
+#define RTC_SEC_BIT_LEN_MASK    0x7F
+#define RTC_CENT_BIT_LEN_MASK   0x7F
+#define RTC_YEAR_BIT_LEN_MASK   0xFF
+#define RTC_MONTH_BIT_LEN_MASK  0x1F
+#define RTC_DATE_BIT_LEN_MASK   0x3F
+#define RTC_WEEK_BIT_LEN_MASK   0x07
+
+/*----------------------------------------------------------------------------
  *        Internal functions
  *----------------------------------------------------------------------------*/
  


### PR DESCRIPTION
There is an essential problem without these 2 new functions:

- Determining time and date by subsequent calls of RTC_GetTime() and
RTC_GetDate() will retrieve a wrong result, when there happens a day
transition between the 2 calls.

- Setting time and date by subsequent calls of RTC_SetTime() and
RTC_SetDate() will result in a wrong setting, when there happens a day
transition between the 2 calls.
Since time synchronization happens today over networks it isn't totally
unlikely that time will be set to 23:59:59.
Reason2:
2 Subsequent calls will result in a 2 times wait for the RTC_SR_ACKUPD
flag of RTC_SR. A single wait consumes processor time by polling in a
loop for 1 second (as per microcontroller data sheet section 14.5.5).

This PR has also a bugfix and removed unnecessary data from rtc.h. Refer to comments of the commits. 