### PR TITLE
Make USART IRQ handler WEAK

### DIFF
--- a/variants/arduino_due_x/variant.cpp
+++ b/variants/arduino_due_x/variant.cpp
@@ -336,20 +336,21 @@ void serialEvent3() __attribute__((weak));
 void serialEvent3() { }
 
 // IT handlers
-void USART0_Handler(void)
+__attribute__((weak)) void USART0_Handler(void)
 {
   Serial1.IrqHandler();
 }
 
-void USART1_Handler(void)
+__attribute__((weak)) void USART1_Handler(void)
 {
   Serial2.IrqHandler();
 }
 
-void USART3_Handler(void)
+__attribute__((weak)) void USART3_Handler(void)
 {
   Serial3.IrqHandler();
 }
+
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Description:
This patch modifies the predefined USART IRQ handlers in the Arduino Due core to be declared __attribute__((weak)).

Motivation:

- Allows libraries, such as ['DUERS485DMA'](https://github.com/NitrofMtl/DUERS485DMA), to override the default USART interrupt handlers.

- Necessary for DMA-based RS485 implementations that require custom IRQ handling without modifying the core itself.

Changes:

- All predefined USARTx_Handler() functions are now weak.

- Existing functionality remains unchanged if no library overrides the handler.

- No effect on boards or configurations that do not use these handlers.

Impact:

- Compatible with existing sketches using standard Serial objects.

- Enables advanced libraries to implement DMA or custom serial processing.

Notes:

- Only the weak attribute is added; the logic inside the handlers is untouched.

- Users may override handlers selectively (only the USARTs they use).